### PR TITLE
1. Move the current head command to the new command mds_head; 2. Change the semantics of the head command

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -88,6 +88,23 @@ impl Client {
         Response(frugalos::HeadObjectRpc::client(&self.rpc_service).call(self.server, request))
     }
 
+    /// `HeadObjectRpc`を実行する。
+    pub fn mds_head_object(
+        &self,
+        bucket_id: BucketId,
+        object_id: ObjectId,
+        deadline: Duration,
+        expect: Expect,
+    ) -> impl Future<Item = Option<ObjectVersion>, Error = Error> {
+        let request = frugalos::ObjectRequest {
+            bucket_id,
+            object_id,
+            deadline,
+            expect,
+        };
+        Response(frugalos::MdsHeadObjectRpc::client(&self.rpc_service).call(self.server, request))
+    }
+
     /// `PutObjectRpc`を実行する。
     pub fn put_object(
         &self,

--- a/src/client/mds.rs
+++ b/src/client/mds.rs
@@ -65,6 +65,20 @@ impl Client {
         Call::<mds::GetObjectRpc, _>::new(self, request)
     }
 
+    /// `MdsHeadObjectRpc`を実行する。
+    pub fn mds_head_object(
+        &self,
+        id: ObjectId,
+        expect: Expect,
+    ) -> impl Future<Item = (Option<RemoteNodeId>, Option<ObjectVersion>), Error = Error> {
+        let request = mds::ObjectRequest {
+            node_id: self.node.1.clone(),
+            object_id: id,
+            expect,
+        };
+        Call::<mds::MdsHeadObjectRpc, _>::new(self, request)
+    }
+
     /// `HeadObjectRpc`を実行する。
     pub fn head_object(
         &self,
@@ -78,7 +92,7 @@ impl Client {
         };
         Call::<mds::HeadObjectRpc, _>::new(self, request)
     }
-
+    
     /// `PutObjectRpc`を実行する。
     pub fn put_object(
         &self,

--- a/src/client/mds.rs
+++ b/src/client/mds.rs
@@ -92,7 +92,7 @@ impl Client {
         };
         Call::<mds::HeadObjectRpc, _>::new(self, request)
     }
-    
+
     /// `PutObjectRpc`を実行する。
     pub fn put_object(
         &self,

--- a/src/entity/object.rs
+++ b/src/entity/object.rs
@@ -56,7 +56,7 @@ mod prefix_summary_total {
     use std::fmt::Display;
     use std::str::FromStr;
 
-    #[cfg_attr(feature = "cargo-clippy", allow(trivially_copy_pass_by_ref))]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S>(x: &u64, s: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -189,6 +189,22 @@ impl Call for DeleteObjectSetFromDeviceRpc {
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
 
+/// オブジェクト存在確認RPC。
+#[derive(Debug)]
+pub struct MdsHeadObjectRpc;
+impl Call for MdsHeadObjectRpc {
+    const ID: ProcedureId = ProcedureId(0x0009_000b);
+    const NAME: &'static str = "frugalos.object.mds_head";
+
+    type Req = ObjectRequest;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+
+    type Res = Result<Option<ObjectVersion>>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+}
+
 /// オブジェクト単位のRPC要求。
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/schema/mds.rs
+++ b/src/schema/mds.rs
@@ -203,6 +203,22 @@ impl Call for DeleteObjectsByPrefixRpc {
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
 
+/// オブジェクト存在確認RPC。
+#[derive(Debug)]
+pub struct MdsHeadObjectRpc;
+impl Call for MdsHeadObjectRpc {
+    const ID: ProcedureId = ProcedureId(0x0008_000a);
+    const NAME: &'static str = "frugalos.mds.object.mds_head";
+
+    type Req = ObjectRequest;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+
+    type Res = Result<Option<ObjectVersion>>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+}
+
 /// オブジェクト単位の要求。
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
# Background
This PR deals with the issue https://github.com/frugalos/frugalos/issues/84

# Summary
In this PR, we do the followings
1. save the current behavior of the `head` command as the new command `mds_head`.
2. change the semantics of the `head` command to ensure that we can really retrieve the content of a designated object when the new `head` command returns `true` for the object.