### PR TITLE
Fix a clippy warning

### DIFF
--- a/src/entity/object.rs
+++ b/src/entity/object.rs
@@ -56,7 +56,7 @@ mod prefix_summary_total {
     use std::fmt::Display;
     use std::str::FromStr;
 
-    #[cfg_attr(feature = "cargo-clippy", allow(trivially_copy_pass_by_ref))]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S>(x: &u64, s: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
Fixed the following warning:

```console
warning: lint name `trivially_copy_pass_by_ref` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
  --> src/entity/object.rs:59:48
   |
59 |     #[cfg_attr(feature = "cargo-clippy", allow(trivially_copy_pass_by_ref))]
   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change it to: `clippy::trivially_copy_pass_by_ref`
```