### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfrugalos"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["The FrugalOS Developers"]
 description = "This crate defines the public interface of `frugalos` for related tools"
 homepage = "https://github.com/frugalos/libfrugalos"


### PR DESCRIPTION
A new version mainly for https://github.com/frugalos/frugalos/pull/94.