### PR TITLE
Add SetRepairConcurrencyLimitRpc

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -209,4 +209,15 @@ impl Client {
     pub fn take_snapshot(&self) -> impl Future<Item = (), Error = Error> {
         Response(frugalos::TakeSnapshotRpc::client(&self.rpc_service).call(self.server, ()))
     }
+
+    /// Executes `SetRepairConcurrencyLimitRpc`.
+    pub fn set_repair_concurrency_limit(
+        &self,
+        repair_concurrency_limit: i64,
+    ) -> impl Future<Item = (), Error = Error> {
+        Response(
+            frugalos::SetRepairConcurrencyLimitRpc::client(&self.rpc_service)
+                .call(self.server, repair_concurrency_limit),
+        )
+    }
 }

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -291,3 +291,19 @@ impl Call for TakeSnapshotRpc {
     type ResDecoder = BincodeDecoder<Self::Res>;
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
+
+/// An RPC for changing repair_concurrency_limit.
+#[derive(Debug)]
+pub struct SetRepairConcurrencyLimitRpc;
+impl Call for SetRepairConcurrencyLimitRpc {
+    const ID: ProcedureId = ProcedureId(0x000a_0003);
+    const NAME: &'static str = "frugalos.ctrl.set_repair_concurrency_limit";
+
+    type Req = i64;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+
+    type Res = Result<()>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+}


### PR DESCRIPTION
An RPC to prevent too many `SegmentNode`s from running simultaneously and using too much CPU.