### PR TITLE
Add SetRepairSettingsRpc

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -14,8 +14,8 @@ use entity::object::{
     DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
+use repair::RepairSettings;
 use schema::frugalos;
-use schema::frugalos::RepairSettings;
 use Error;
 
 /// RPCクライアント。

--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -14,7 +14,7 @@ use entity::object::{
     DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
-use repair::RepairSettings;
+use repair::RepairConfig;
 use schema::frugalos;
 use Error;
 
@@ -211,14 +211,14 @@ impl Client {
         Response(frugalos::TakeSnapshotRpc::client(&self.rpc_service).call(self.server, ()))
     }
 
-    /// Executes `SetRepairSettingsRpc`
-    pub fn set_repair_settings(
+    /// Executes `SetRepairConfigRpc`
+    pub fn set_repair_config(
         &self,
-        repair_settings: RepairSettings,
+        repair_config: RepairConfig,
     ) -> impl Future<Item = (), Error = Error> {
         Response(
-            frugalos::SetRepairSettingsRpc::client(&self.rpc_service)
-                .call(self.server, repair_settings),
+            frugalos::SetRepairConfigRpc::client(&self.rpc_service)
+                .call(self.server, repair_config),
         )
     }
 }

--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -15,7 +15,7 @@ use entity::object::{
 };
 use expect::Expect;
 use schema::frugalos;
-use schema::frugalos::SegmentSettings;
+use schema::frugalos::RepairSettings;
 use Error;
 
 /// RPCクライアント。
@@ -211,14 +211,14 @@ impl Client {
         Response(frugalos::TakeSnapshotRpc::client(&self.rpc_service).call(self.server, ()))
     }
 
-    /// Executes `SetSegmentSettingsRpc`
-    pub fn set_segment_settings(
+    /// Executes `SetRepairSettingsRpc`
+    pub fn set_repair_settings(
         &self,
-        segment_settings: SegmentSettings,
+        repair_settings: RepairSettings,
     ) -> impl Future<Item = (), Error = Error> {
         Response(
-            frugalos::SetSegmentSettingsRpc::client(&self.rpc_service)
-                .call(self.server, segment_settings),
+            frugalos::SetRepairSettingsRpc::client(&self.rpc_service)
+                .call(self.server, repair_settings),
         )
     }
 }

--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -15,6 +15,7 @@ use entity::object::{
 };
 use expect::Expect;
 use schema::frugalos;
+use schema::frugalos::SegmentSettings;
 use Error;
 
 /// RPCクライアント。
@@ -208,5 +209,16 @@ impl Client {
     /// `TakeSnapshotRpc`を実行する。
     pub fn take_snapshot(&self) -> impl Future<Item = (), Error = Error> {
         Response(frugalos::TakeSnapshotRpc::client(&self.rpc_service).call(self.server, ()))
+    }
+
+    /// Executes `SetSegmentSettingsRpc`
+    pub fn set_segment_settings(
+        &self,
+        segment_settings: SegmentSettings,
+    ) -> impl Future<Item = (), Error = Error> {
+        Response(
+            frugalos::SetSegmentSettingsRpc::client(&self.rpc_service)
+                .call(self.server, segment_settings),
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod client;
 pub mod deadline;
 pub mod entity;
 pub mod expect;
+pub mod repair;
 pub mod schema;
 pub mod time;
 

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -18,11 +18,11 @@ pub struct RepairConcurrencyLimit(pub u64);
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct FullSyncConcurrencyLimit(pub u64);
 
-/// Settings of frugalos_segment's repair functionality.
+/// Configuration of frugalos_segment's repair functionality.
 /// If a field is None, that field will remain unchanged.
 /// If a field is Some(val), that field will change to val.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RepairSettings {
+pub struct RepairConfig {
     /// SegmentService::repair_concurrency_limit
     pub repair_concurrency_limit: Option<RepairConcurrencyLimit>,
     /// Synchronizer::repair_idleness_threshold

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -14,9 +14,9 @@ pub enum RepairIdleness {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct RepairConcurrencyLimit(pub u64);
 
-/// The maximum number of threads to execute full_sync.
+/// The maximum number of threads to execute segment_gc.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct FullSyncConcurrencyLimit(pub u64);
+pub struct SegmentGcConcurrencyLimit(pub u64);
 
 /// Configuration of frugalos_segment's repair functionality.
 /// If a field is None, that field will remain unchanged.
@@ -27,6 +27,6 @@ pub struct RepairConfig {
     pub repair_concurrency_limit: Option<RepairConcurrencyLimit>,
     /// Synchronizer::repair_idleness_threshold
     pub repair_idleness_threshold: Option<RepairIdleness>,
-    /// SegmentService::full_sync_concurrency_limit
-    pub full_sync_concurrency_limit: Option<FullSyncConcurrencyLimit>,
+    /// SegmentService::segment_gc_concurrency_limit
+    pub segment_gc_concurrency_limit: Option<SegmentGcConcurrencyLimit>,
 }

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -1,0 +1,32 @@
+//! Definitions related to repair functionality.
+use std::time::Duration;
+
+/// A value that eventually goes into Synchronizer::repair_idleness_threshold.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum RepairIdleness {
+    /// Repair should wait for the given duration of idleness.
+    Threshold(Duration),
+    /// Repair is disabled.
+    Disabled,
+}
+
+/// The maximum number of threads to execute repairing.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct RepairConcurrencyLimit(pub u64);
+
+/// The maximum number of threads to execute full_sync.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct FullSyncConcurrencyLimit(pub u64);
+
+/// Settings of frugalos_segment's repair functionality.
+/// If a field is None, that field will remain unchanged.
+/// If a field is Some(val), that field will change to val.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepairSettings {
+    /// SegmentService::repair_concurrency_limit
+    pub repair_concurrency_limit: Option<RepairConcurrencyLimit>,
+    /// Synchronizer::repair_idleness_threshold
+    pub repair_idleness_threshold: Option<RepairIdleness>,
+    /// SegmentService::full_sync_concurrency_limit
+    pub full_sync_concurrency_limit: Option<FullSyncConcurrencyLimit>,
+}

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -319,7 +319,7 @@ pub struct RepairSettings {
 pub struct SetRepairSettingsRpc;
 impl Call for SetRepairSettingsRpc {
     const ID: ProcedureId = ProcedureId(0x000a_0002);
-    const NAME: &'static str = "frugalos.ctrl.set_segment_settings";
+    const NAME: &'static str = "frugalos.ctrl.set_repair_settings";
 
     type Req = RepairSettings;
     type ReqEncoder = BincodeEncoder<Self::Req>;

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -301,25 +301,25 @@ pub enum RepairIdleness {
     Disabled,
 }
 
-/// Settings of frugalos_segment.
+/// Settings of frugalos_segment's repair functionality.
 /// If a field is None, that field will remain unchanged.
 /// If a field is Some(val), that field will change to val.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SegmentSettings {
+pub struct RepairSettings {
     /// SegmentService::repair_concurrency_limit
     pub repair_concurrency_limit: Option<u64>,
     /// Synchronizer::repair_idleness_threshold
     pub repair_idleness_threshold: Option<RepairIdleness>,
 }
 
-/// An RPC for changing repair_idleness_threshold.
+/// An RPC for changing settings fo repair functionality.
 #[derive(Debug)]
-pub struct SetSegmentSettingsRpc;
-impl Call for SetSegmentSettingsRpc {
+pub struct SetRepairSettingsRpc;
+impl Call for SetRepairSettingsRpc {
     const ID: ProcedureId = ProcedureId(0x000a_0002);
     const NAME: &'static str = "frugalos.ctrl.set_segment_settings";
 
-    type Req = SegmentSettings;
+    type Req = RepairSettings;
     type ReqEncoder = BincodeEncoder<Self::Req>;
     type ReqDecoder = BincodeDecoder<Self::Req>;
 

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -310,6 +310,8 @@ pub struct RepairSettings {
     pub repair_concurrency_limit: Option<u64>,
     /// Synchronizer::repair_idleness_threshold
     pub repair_idleness_threshold: Option<RepairIdleness>,
+    /// SegmentService::full_sync_concurrency_limit
+    pub full_sync_concurrency_limit: Option<u64>,
 }
 
 /// An RPC for changing settings fo repair functionality.

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -11,7 +11,7 @@ use entity::object::{
     DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
-use repair::RepairSettings;
+use repair::RepairConfig;
 use Result;
 
 /// オブジェクト取得RPC。
@@ -293,14 +293,14 @@ impl Call for TakeSnapshotRpc {
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
 
-/// An RPC for changing settings fo repair functionality.
+/// An RPC for changing configuration of repair functionality.
 #[derive(Debug)]
-pub struct SetRepairSettingsRpc;
-impl Call for SetRepairSettingsRpc {
+pub struct SetRepairConfigRpc;
+impl Call for SetRepairConfigRpc {
     const ID: ProcedureId = ProcedureId(0x000a_0002);
-    const NAME: &'static str = "frugalos.ctrl.set_repair_settings";
+    const NAME: &'static str = "frugalos.ctrl.set_repair_config";
 
-    type Req = RepairSettings;
+    type Req = RepairConfig;
     type ReqEncoder = BincodeEncoder<Self::Req>;
     type ReqDecoder = BincodeDecoder<Self::Req>;
 

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -291,3 +291,39 @@ impl Call for TakeSnapshotRpc {
     type ResDecoder = BincodeDecoder<Self::Res>;
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
+
+/// A value that eventually goes into Synchronizer::repair_idleness_threshold.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RepairIdleness {
+    /// Repair should wait for the given duration of idleness.
+    Threshold(Duration),
+    /// Repair is disabled.
+    Disabled,
+}
+
+/// Settings of frugalos_segment.
+/// If a field is None, that field will remain unchanged.
+/// If a field is Some(val), that field will change to val.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SegmentSettings {
+    /// SegmentService::repair_concurrency_limit
+    pub repair_concurrency_limit: Option<u64>,
+    /// Synchronizer::repair_idleness_threshold
+    pub repair_idleness_threshold: Option<RepairIdleness>,
+}
+
+/// An RPC for changing repair_idleness_threshold.
+#[derive(Debug)]
+pub struct SetSegmentSettingsRpc;
+impl Call for SetSegmentSettingsRpc {
+    const ID: ProcedureId = ProcedureId(0x000a_0002);
+    const NAME: &'static str = "frugalos.ctrl.set_segment_settings";
+
+    type Req = SegmentSettings;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+
+    type Res = Result<()>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+}

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -11,6 +11,7 @@ use entity::object::{
     DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
+use repair::RepairSettings;
 use Result;
 
 /// オブジェクト取得RPC。
@@ -290,28 +291,6 @@ impl Call for TakeSnapshotRpc {
     type Res = Result<()>;
     type ResDecoder = BincodeDecoder<Self::Res>;
     type ResEncoder = BincodeEncoder<Self::Res>;
-}
-
-/// A value that eventually goes into Synchronizer::repair_idleness_threshold.
-#[derive(Debug, Serialize, Deserialize)]
-pub enum RepairIdleness {
-    /// Repair should wait for the given duration of idleness.
-    Threshold(Duration),
-    /// Repair is disabled.
-    Disabled,
-}
-
-/// Settings of frugalos_segment's repair functionality.
-/// If a field is None, that field will remain unchanged.
-/// If a field is Some(val), that field will change to val.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct RepairSettings {
-    /// SegmentService::repair_concurrency_limit
-    pub repair_concurrency_limit: Option<u64>,
-    /// Synchronizer::repair_idleness_threshold
-    pub repair_idleness_threshold: Option<RepairIdleness>,
-    /// SegmentService::full_sync_concurrency_limit
-    pub full_sync_concurrency_limit: Option<u64>,
 }
 
 /// An RPC for changing settings fo repair functionality.


### PR DESCRIPTION
## 概要
SetRepairSettingsRpc will be added. It can perform two operations:
- repair_concurrency_limit, to prevent too many SegmentNodes from running simultaneously and using too much CPU.
- repair_idleness_threshold, for use in https://github.com/frugalos/frugalos/pull/190.
- full_sync_concurrency_limit, to prevent too many SegmentNodes from performing [repair for deleted objects](https://github.com/frugalos/frugalos/pull/166) simultaneously and using too much memory.

## 補足
frugalos チームでの協議の結果、segment の設定 (GET/PUT の timeout など) はこの rpc では変更できないようにし、この rpc ではリペア機能の設定のみを扱うことにしました。それに従い、ここで追加される構造体の名前も Segment から Repair にリネームしました。