### PR TITLE
Add MultiplicityConfig

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -14,6 +14,7 @@ use entity::object::{
     DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
+use multiplicity::MultiplicityConfig;
 use repair::RepairConfig;
 use schema::frugalos;
 use Error;
@@ -97,6 +98,7 @@ impl Client {
         content: Vec<u8>,
         deadline: Duration,
         expect: Expect,
+        multiplicity_config: MultiplicityConfig,
     ) -> impl Future<Item = (ObjectVersion, bool), Error = Error> {
         let request = frugalos::PutObjectRequest {
             bucket_id,
@@ -104,6 +106,7 @@ impl Client {
             content,
             deadline,
             expect,
+            multiplicity_config,
         };
         Response(frugalos::PutObjectRpc::client(&self.rpc_service).call(self.server, request))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod client;
 pub mod deadline;
 pub mod entity;
 pub mod expect;
+pub mod multiplicity;
 pub mod repair;
 pub mod schema;
 pub mod time;

--- a/src/multiplicity.rs
+++ b/src/multiplicity.rs
@@ -1,0 +1,19 @@
+//! 多重度に関する設定をまとめたモジュール。
+
+/// 多重度に関する設定。
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MultiplicityConfig {
+    pub inner_retry_count: InnerRetryCount,
+    pub number_of_ensured_saves: NumberOfEnsuredSaves,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+/// How many times frugalos_segment retries to save the object.
+/// Defaults to 0.
+pub struct InnerRetryCount(pub usize);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+/// Number of objects ensured to be saved, apart from data_fragment.
+/// Defaults to 0.
+pub struct NumberOfEnsuredSaves(pub usize);

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -11,6 +11,7 @@ use entity::object::{
     DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
+use multiplicity::MultiplicityConfig;
 use repair::RepairConfig;
 use Result;
 
@@ -238,6 +239,7 @@ pub struct PutObjectRequest {
     pub content: Vec<u8>,
     pub deadline: Duration,
     pub expect: Expect,
+    pub multiplicity_config: MultiplicityConfig,
 }
 
 /// セグメント単位でのRPC要求。


### PR DESCRIPTION
PUT で多重度についてのパラメタを設定できるようにするための変更である。

## 目的
オブジェクトの PUT 時にフラグメントの保存に失敗する可能性があり、以下の2点の対策をしたいため:
- フラグメントの保存を最後までやる
- フラグメントの保存に失敗した際に内部でリトライを行う

## 変更点
MultiplicityConfig 構造体を定義し、 PutObjectRequest に MultiplicityConfig を含めた。