### PR TITLE
Add HeadObjectRequest for HeadObjectRpc

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -83,7 +83,7 @@ impl Client {
         deadline: Duration,
         expect: Expect,
         consistency: ReadConsistency,
-        storage: bool,
+        check_storage: bool,
     ) -> impl Future<Item = Option<ObjectVersion>, Error = Error> {
         let request = frugalos::HeadObjectRequest {
             bucket_id,
@@ -91,7 +91,7 @@ impl Client {
             deadline,
             expect,
             consistency: Some(consistency),
-            storage,
+            check_storage,
         };
         Response(frugalos::HeadObjectRpc::client(&self.rpc_service).call(self.server, request))
     }

--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -90,7 +90,7 @@ impl Client {
             object_id,
             deadline,
             expect,
-            consistency: Some(consistency),
+            consistency,
             check_storage,
         };
         Response(frugalos::HeadObjectRpc::client(&self.rpc_service).call(self.server, request))

--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -83,13 +83,15 @@ impl Client {
         deadline: Duration,
         expect: Expect,
         consistency: ReadConsistency,
+        storage: bool,
     ) -> impl Future<Item = Option<ObjectVersion>, Error = Error> {
-        let request = frugalos::ObjectRequest {
+        let request = frugalos::HeadObjectRequest {
             bucket_id,
             object_id,
             deadline,
             expect,
             consistency: Some(consistency),
+            storage,
         };
         Response(frugalos::HeadObjectRpc::client(&self.rpc_service).call(self.server, request))
     }

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -210,7 +210,7 @@ pub struct HeadObjectRequest {
     pub object_id: ObjectId,
     pub deadline: Duration,
     pub expect: Expect,
-    pub consistency: Option<ReadConsistency>,
+    pub consistency: ReadConsistency,
     /// ストレージ側にも問い合わせるかどうか
     pub check_storage: bool,
 }

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -39,7 +39,7 @@ impl Call for HeadObjectRpc {
     const ID: ProcedureId = ProcedureId(0x0009_0001);
     const NAME: &'static str = "frugalos.object.head";
 
-    type Req = ObjectRequest;
+    type Req = HeadObjectRequest;
     type ReqDecoder = BincodeDecoder<Self::Req>;
     type ReqEncoder = BincodeEncoder<Self::Req>;
 
@@ -200,6 +200,19 @@ pub struct ObjectRequest {
     pub deadline: Duration,
     pub expect: Expect,
     pub consistency: Option<ReadConsistency>,
+}
+
+/// オブジェクト単位の存在確認 RPC 要求。
+#[allow(missing_docs)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HeadObjectRequest {
+    pub bucket_id: BucketId,
+    pub object_id: ObjectId,
+    pub deadline: Duration,
+    pub expect: Expect,
+    pub consistency: Option<ReadConsistency>,
+    /// ストレージ側にも問い合わせるかどうか
+    pub storage: bool,
 }
 
 /// バージョン単位のRPC要求。

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -212,7 +212,7 @@ pub struct HeadObjectRequest {
     pub expect: Expect,
     pub consistency: Option<ReadConsistency>,
     /// ストレージ側にも問い合わせるかどうか
-    pub storage: bool,
+    pub check_storage: bool,
 }
 
 /// バージョン単位のRPC要求。


### PR DESCRIPTION
## 概要
frugalos の HEAD リクエストでは mds までしか問い合わせが行われないが、storage 側にも存在確認を要求するための変更

## 変更点
- `struct HeadObjectRequest` の追加
- 既存の HeadObjectRpc の Req を `ObjectRequest` から `HeadObjectRequest` に変更