### PR TITLE
Supports `fn list_objects_by_prefix`

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -63,6 +63,23 @@ impl Client {
         Response(frugalos::ListObjectsRpc::client(&self.rpc_service).call(self.server, request))
     }
 
+    /// `ListObjectsByPrefixRpc`を実行する。
+    pub fn list_objects_by_prefix(
+        &self,
+        bucket_id: BucketId,
+        prefix: ObjectPrefix,
+        deadline: Duration,
+    ) -> impl Future<Item = Vec<ObjectSummary>, Error = Error> {
+        let request = frugalos::PrefixRequest {
+            bucket_id,
+            prefix,
+            deadline,
+        };
+        Response(
+            frugalos::ListObjectsByPrefixRpc::client(&self.rpc_service).call(self.server, request),
+        )
+    }
+
     /// `GetLatestVersionRpc`を実行する。
     pub fn latest_version(
         &self,

--- a/src/client/mds.rs
+++ b/src/client/mds.rs
@@ -40,6 +40,18 @@ impl Client {
         Call::<mds::ListObjectsRpc, _>::new(self, self.node.1.clone())
     }
 
+    /// `ListObjectsByPrefixRpc`を実行する。
+    pub fn list_objects_by_prefix(
+        &self,
+        prefix: ObjectPrefix,
+    ) -> impl Future<Item = (Option<RemoteNodeId>, Vec<ObjectSummary>), Error = Error> {
+        let request = mds::PrefixRequest {
+            node_id: self.node.1.clone(),
+            prefix,
+        };
+        Call::<mds::ListObjectsByPrefixRpc, _>::new(self, request)
+    }
+
     /// `GetLatestVersionRpc`を実行する。
     pub fn latest_version(
         &self,

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -191,6 +191,26 @@ impl Call for DeleteObjectSetFromDeviceRpc {
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
 
+/// 接頭辞指定でのオブジェクト一覧取得RPC。
+#[derive(Debug)]
+pub struct ListObjectsByPrefixRpc;
+impl Call for ListObjectsByPrefixRpc {
+    const ID: ProcedureId = ProcedureId(0x0009_000b);
+    const NAME: &'static str = "frugalos.object.list_by_prefix";
+
+    type Req = PrefixRequest;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+
+    type Res = Result<Vec<ObjectSummary>>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+
+    fn enable_async_response(_: &Self::Res) -> bool {
+        true
+    }
+}
+
 /// オブジェクト単位のRPC要求。
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/schema/mds.rs
+++ b/src/schema/mds.rs
@@ -204,6 +204,26 @@ impl Call for DeleteObjectsByPrefixRpc {
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
 
+/// 接頭辞指定でのオブジェクト一覧取得RPC。
+#[derive(Debug)]
+pub struct ListObjectsByPrefixRpc;
+impl Call for ListObjectsByPrefixRpc {
+    const ID: ProcedureId = ProcedureId(0x0008_000a);
+    const NAME: &'static str = "frugalos.mds.object.list_by_prefix";
+
+    type Req = PrefixRequest;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+
+    type Res = Result<Vec<ObjectSummary>>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+
+    fn enable_async_response(_: &Self::Res) -> bool {
+        true
+    }
+}
+
 /// オブジェクト単位の要求。
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Purpose

オブジェクトの接頭辞指定でのオブジェクト一覧を取得するための RPC とメソッドを追加する。オブジェクトIDを完全に把握していないが、先頭の共通部分は分かっているというケースで接頭辞指定でオブジェクト一覧を取得したいことがある。

すでに実装されている「セグメント指定でのオブジェクト一覧取得」でもオブジェクト一覧が取得できるが、セグメントとオブジェクトIDの対応を先に知る必要があり開発時には非常に不便なので、オブジェクトID(の接頭辞指定)ベースでオブジェクトを一覧できるようにしたい。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.