### PR TITLE
Supports `ReadConsistency` for `ListObjectsRpc`, `GetObjectCountRpc`

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -58,8 +58,13 @@ impl Client {
         &self,
         bucket_id: BucketId,
         segment: u16,
+        consistency: ReadConsistency,
     ) -> impl Future<Item = Vec<ObjectSummary>, Error = Error> {
-        let request = frugalos::SegmentRequest { bucket_id, segment };
+        let request = frugalos::ListObjectsRequest {
+            bucket_id,
+            segment,
+            consistency,
+        };
         Response(frugalos::ListObjectsRpc::client(&self.rpc_service).call(self.server, request))
     }
 

--- a/src/client/mds.rs
+++ b/src/client/mds.rs
@@ -36,8 +36,13 @@ impl Client {
     /// `ListObjectsRpc`を実行する。
     pub fn list_objects(
         &self,
+        consistency: ReadConsistency,
     ) -> impl Future<Item = (Option<RemoteNodeId>, Vec<ObjectSummary>), Error = Error> {
-        Call::<mds::ListObjectsRpc, _>::new(self, self.node.1.clone())
+        let request = mds::ListObjectsRequest {
+            node_id: self.node.1.clone(),
+            consistency,
+        };
+        Call::<mds::ListObjectsRpc, _>::new(self, request)
     }
 
     /// `GetLatestVersionRpc`を実行する。
@@ -48,8 +53,15 @@ impl Client {
     }
 
     /// セグメントが保持しているオブジェクトの数を返す.
-    pub fn object_count(&self) -> impl Future<Item = (Option<RemoteNodeId>, u64), Error = Error> {
-        Call::<mds::GetObjectCountRpc, _>::new(self, self.node.1.clone())
+    pub fn object_count(
+        &self,
+        consistency: ReadConsistency,
+    ) -> impl Future<Item = (Option<RemoteNodeId>, u64), Error = Error> {
+        let request = mds::ObjectCountRequest {
+            node_id: self.node.1.clone(),
+            consistency,
+        };
+        Call::<mds::GetObjectCountRpc, _>::new(self, request)
     }
 
     /// `GetObjectRpc`を実行する。
@@ -164,7 +176,17 @@ impl SetNodeId for LocalNodeId {
         *self = node_id;
     }
 }
+impl SetNodeId for mds::ListObjectsRequest {
+    fn set_node_id(&mut self, node_id: LocalNodeId) {
+        self.node_id = node_id;
+    }
+}
 impl SetNodeId for mds::ObjectRequest {
+    fn set_node_id(&mut self, node_id: LocalNodeId) {
+        self.node_id = node_id;
+    }
+}
+impl SetNodeId for mds::ObjectCountRequest {
     fn set_node_id(&mut self, node_id: LocalNodeId) {
         self.node_id = node_id;
     }

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -88,7 +88,7 @@ impl Call for ListObjectsRpc {
     const ID: ProcedureId = ProcedureId(0x0009_0004);
     const NAME: &'static str = "frugalos.object.list";
 
-    type Req = SegmentRequest;
+    type Req = ListObjectsRequest;
     type ReqDecoder = BincodeDecoder<Self::Req>;
     type ReqEncoder = BincodeEncoder<Self::Req>;
 
@@ -253,6 +253,15 @@ pub struct PutObjectRequest {
     pub content: Vec<u8>,
     pub deadline: Duration,
     pub expect: Expect,
+}
+
+/// オブジェクト一覧要求。
+#[allow(missing_docs)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListObjectsRequest {
+    pub bucket_id: BucketId,
+    pub segment: u16,
+    pub consistency: ReadConsistency,
 }
 
 /// セグメント単位でのRPC要求。

--- a/src/schema/mds.rs
+++ b/src/schema/mds.rs
@@ -47,7 +47,7 @@ impl Call for ListObjectsRpc {
     const ID: ProcedureId = ProcedureId(0x0008_0000);
     const NAME: &'static str = "frugalos.mds.object.list";
 
-    type Req = LocalNodeId;
+    type Req = ListObjectsRequest;
     type ReqDecoder = BincodeDecoder<Self::Req>;
     type ReqEncoder = BincodeEncoder<Self::Req>;
 
@@ -179,7 +179,7 @@ impl Call for GetObjectCountRpc {
     const ID: ProcedureId = ProcedureId(0x0008_0008);
     const NAME: &'static str = "frugalos.mds.object.count";
 
-    type Req = LocalNodeId;
+    type Req = ObjectCountRequest;
     type ReqDecoder = BincodeDecoder<Self::Req>;
     type ReqEncoder = BincodeEncoder<Self::Req>;
 
@@ -212,6 +212,22 @@ pub struct ObjectRequest {
     pub object_id: ObjectId,
     pub expect: Expect,
     pub consistency: Option<ReadConsistency>,
+}
+
+/// オブジェクト一覧の要求。
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListObjectsRequest {
+    pub node_id: LocalNodeId,
+    pub consistency: ReadConsistency,
+}
+
+/// オブジェクトカウントの要求。
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectCountRequest {
+    pub node_id: LocalNodeId,
+    pub consistency: ReadConsistency,
 }
 
 /// バージョン単位の要求。


### PR DESCRIPTION
## Types of changes
<!--- copied from https://github.com/stevemao/github-issue-templates/blob/master/checklist2/PULL_REQUEST_TEMPLATE.md --->
Please check one of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New release (merge to both `master` and `develop`!)

## Description of changes

### Behavior

RPC の互換性がなくなるぐらいで他は特に変更なし。

### Purpose

オブジェクトの一覧取得とオブジェクト個数のカウント用 RPC で整合性の指定に対応するために、RPC の定義を変更すること。

## Checklists

- Run `cargo fmt --all`.
- Run `cargo clippy --all --all-targets`.