### PR TITLE
Add CountFragmentsRpc to count all fragments of an object

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -12,8 +12,8 @@ use consistency::ReadConsistency;
 use entity::bucket::BucketId;
 use entity::device::DeviceId;
 use entity::object::{
-    CountFragments, DeleteObjectsByPrefixSummary, HeadObjectSummary, ObjectId, ObjectPrefix,
-    ObjectSummary, ObjectVersion,
+    DeleteObjectsByPrefixSummary, FragmentsSummary, ObjectId, ObjectPrefix, ObjectSummary,
+    ObjectVersion,
 };
 use expect::Expect;
 use multiplicity::MultiplicityConfig;
@@ -94,6 +94,25 @@ impl Client {
         )
     }
 
+    /// `CountFragmentsRpc`を実行する。
+    pub fn count_fragments(
+        &self,
+        bucket_id: BucketId,
+        object_id: ObjectId,
+        deadline: Duration,
+        expect: Expect,
+        consistency: ReadConsistency,
+    ) -> impl Future<Item = Option<FragmentsSummary>, Error = Error> {
+        let request = frugalos::CountFragmentsRequest {
+            bucket_id,
+            object_id,
+            deadline,
+            expect,
+            consistency,
+        };
+        Response(frugalos::CountFragmentsRpc::client(&self.rpc_service).call(self.server, request))
+    }
+
     /// `HeadObjectRpc`を実行する。
     pub fn head_object(
         &self,
@@ -103,8 +122,7 @@ impl Client {
         expect: Expect,
         consistency: ReadConsistency,
         check_storage: bool,
-        count_fragments: CountFragments,
-    ) -> impl Future<Item = Option<HeadObjectSummary>, Error = Error> {
+    ) -> impl Future<Item = Option<ObjectVersion>, Error = Error> {
         let request = frugalos::HeadObjectRequest {
             bucket_id,
             object_id,
@@ -112,7 +130,6 @@ impl Client {
             expect,
             consistency,
             check_storage,
-            count_fragments,
         };
         Response(frugalos::HeadObjectRpc::client(&self.rpc_service).call(self.server, request))
     }

--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -12,7 +12,8 @@ use consistency::ReadConsistency;
 use entity::bucket::BucketId;
 use entity::device::DeviceId;
 use entity::object::{
-    DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
+    CountFragments, DeleteObjectsByPrefixSummary, HeadObjectSummary, ObjectId, ObjectPrefix,
+    ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
 use multiplicity::MultiplicityConfig;
@@ -102,7 +103,8 @@ impl Client {
         expect: Expect,
         consistency: ReadConsistency,
         check_storage: bool,
-    ) -> impl Future<Item = Option<ObjectVersion>, Error = Error> {
+        count_fragments: CountFragments,
+    ) -> impl Future<Item = Option<HeadObjectSummary>, Error = Error> {
         let request = frugalos::HeadObjectRequest {
             bucket_id,
             object_id,
@@ -110,6 +112,7 @@ impl Client {
             expect,
             consistency,
             check_storage,
+            count_fragments,
         };
         Response(frugalos::HeadObjectRpc::client(&self.rpc_service).call(self.server, request))
     }

--- a/src/entity/object.rs
+++ b/src/entity/object.rs
@@ -51,6 +51,36 @@ pub struct DeleteObjectsByPrefixSummary {
     pub total: u64,
 }
 
+/// オブジェクト存在確認結果要約
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct HeadObjectSummary {
+    /// バージョン番号.
+    pub version: ObjectVersion,
+    /// フラグメント要約.
+    pub fragments: Option<FragmentsSummary>,
+}
+
+/// フラグメント要約.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct FragmentsSummary {
+    /// 破損しているかどうか.
+    pub is_corrupted: bool,
+    /// デバイス上に存在すべきフラグメント群の内、存在したフラグメント数.
+    pub found_total: u8,
+    /// デバイス上に存在すべきフラグメント群の内、見つからなかったフラグメント数.
+    pub lost_total: u8,
+}
+
+/// フラグメントの個数を数えるかどうかのフラグ。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CountFragments(pub bool);
+
+impl Default for CountFragments {
+    fn default() -> Self {
+        CountFragments(false)
+    }
+}
+
 mod prefix_summary_total {
     use serde::{de, Deserialize, Deserializer, Serializer};
     use std::fmt::Display;

--- a/src/entity/object.rs
+++ b/src/entity/object.rs
@@ -51,15 +51,6 @@ pub struct DeleteObjectsByPrefixSummary {
     pub total: u64,
 }
 
-/// オブジェクト存在確認結果要約
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct HeadObjectSummary {
-    /// バージョン番号.
-    pub version: ObjectVersion,
-    /// フラグメント要約.
-    pub fragments: Option<FragmentsSummary>,
-}
-
 /// フラグメント要約.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct FragmentsSummary {
@@ -69,16 +60,6 @@ pub struct FragmentsSummary {
     pub found_total: u8,
     /// デバイス上に存在すべきフラグメント群の内、見つからなかったフラグメント数.
     pub lost_total: u8,
-}
-
-/// フラグメントの個数を数えるかどうかのフラグ。
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CountFragments(pub bool);
-
-impl Default for CountFragments {
-    fn default() -> Self {
-        CountFragments(false)
-    }
 }
 
 mod prefix_summary_total {

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -9,7 +9,8 @@ use consistency::ReadConsistency;
 use entity::bucket::BucketId;
 use entity::device::DeviceId;
 use entity::object::{
-    DeleteObjectsByPrefixSummary, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
+    CountFragments, DeleteObjectsByPrefixSummary, HeadObjectSummary, ObjectId, ObjectPrefix,
+    ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
 use multiplicity::MultiplicityConfig;
@@ -44,7 +45,7 @@ impl Call for HeadObjectRpc {
     type ReqDecoder = BincodeDecoder<Self::Req>;
     type ReqEncoder = BincodeEncoder<Self::Req>;
 
-    type Res = Result<Option<ObjectVersion>>;
+    type Res = Result<Option<HeadObjectSummary>>;
     type ResDecoder = BincodeDecoder<Self::Res>;
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
@@ -234,6 +235,8 @@ pub struct HeadObjectRequest {
     pub consistency: ReadConsistency,
     /// ストレージ側にも問い合わせるかどうか
     pub check_storage: bool,
+    /// true ならストレージに保存されているフラグメント数も数える
+    pub count_fragments: CountFragments,
 }
 
 /// バージョン単位のRPC要求。

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -9,8 +9,8 @@ use consistency::ReadConsistency;
 use entity::bucket::BucketId;
 use entity::device::DeviceId;
 use entity::object::{
-    CountFragments, DeleteObjectsByPrefixSummary, HeadObjectSummary, ObjectId, ObjectPrefix,
-    ObjectSummary, ObjectVersion,
+    DeleteObjectsByPrefixSummary, FragmentsSummary, ObjectId, ObjectPrefix, ObjectSummary,
+    ObjectVersion,
 };
 use expect::Expect;
 use multiplicity::MultiplicityConfig;
@@ -45,7 +45,7 @@ impl Call for HeadObjectRpc {
     type ReqDecoder = BincodeDecoder<Self::Req>;
     type ReqEncoder = BincodeEncoder<Self::Req>;
 
-    type Res = Result<Option<HeadObjectSummary>>;
+    type Res = Result<Option<ObjectVersion>>;
     type ResDecoder = BincodeDecoder<Self::Res>;
     type ResEncoder = BincodeEncoder<Self::Res>;
 }
@@ -213,6 +213,22 @@ impl Call for ListObjectsByPrefixRpc {
     }
 }
 
+/// フラグメントカウントRPC。
+#[derive(Debug)]
+pub struct CountFragmentsRpc;
+impl Call for CountFragmentsRpc {
+    const ID: ProcedureId = ProcedureId(0x0009_000d);
+    const NAME: &'static str = "frugalos.object.count_fragments";
+
+    type Req = CountFragmentsRequest;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+
+    type Res = Result<Option<FragmentsSummary>>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+}
+
 /// オブジェクト単位のRPC要求。
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize)]
@@ -222,6 +238,17 @@ pub struct ObjectRequest {
     pub deadline: Duration,
     pub expect: Expect,
     pub consistency: Option<ReadConsistency>,
+}
+
+/// フラグメントカウント RPC 要求。
+#[allow(missing_docs)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CountFragmentsRequest {
+    pub bucket_id: BucketId,
+    pub object_id: ObjectId,
+    pub deadline: Duration,
+    pub expect: Expect,
+    pub consistency: ReadConsistency,
 }
 
 /// オブジェクト単位の存在確認 RPC 要求。
@@ -235,8 +262,6 @@ pub struct HeadObjectRequest {
     pub consistency: ReadConsistency,
     /// ストレージ側にも問い合わせるかどうか
     pub check_storage: bool,
-    /// true ならストレージに保存されているフラグメント数も数える
-    pub count_fragments: CountFragments,
 }
 
 /// バージョン単位のRPC要求。


### PR DESCRIPTION
## 目的

デバイス上のフラグメントを数えるかどうかを指定できるようにすること。

frugalos に `Client::count_fragments` を追加する予定です。