### PR TITLE
Supports protobuf for the binary format.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fibers = "0.1"
 fibers_rpc = "0.2"
 futures = "0.1"
 libc = "0.2"
+protobuf_codec = "0.2"
 serde = "1"
 serde_derive = "1"
 trackable = { version = "0.2", features = ["serialize"] }

--- a/src/entity/bucket.rs
+++ b/src/entity/bucket.rs
@@ -36,7 +36,7 @@ pub enum BucketKind {
 }
 impl Default for BucketKind {
     fn default() -> Self {
-        BucketKind::Dispersed
+        BucketKind::Metadata
     }
 }
 

--- a/src/entity/bucket.rs
+++ b/src/entity/bucket.rs
@@ -22,7 +22,7 @@ pub struct BucketSummary {
 }
 
 /// バケツの種類。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BucketKind {
     /// メタデータ用バケツ。

--- a/src/entity/bucket.rs
+++ b/src/entity/bucket.rs
@@ -8,7 +8,7 @@ use entity::device::DeviceId;
 pub type BucketId = String;
 
 /// バケツの内容の要約。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct BucketSummary {
     /// バケツのID。
     pub id: BucketId,
@@ -33,6 +33,11 @@ pub enum BucketKind {
 
     /// ErasureCodingによる冗長化を行うバケツ。
     Dispersed,
+}
+impl Default for BucketKind {
+    fn default() -> Self {
+        BucketKind::Dispersed
+    }
 }
 
 /// バケツ。

--- a/src/entity/device.rs
+++ b/src/entity/device.rs
@@ -15,7 +15,7 @@ pub type DeviceId = String;
 pub type DeviceNo = u32;
 
 /// デバイスの内容の要約。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct DeviceSummary {
     /// デバイスのID。
     pub id: DeviceId,
@@ -43,6 +43,11 @@ pub enum DeviceKind {
 
     /// ファイルデバイス。
     File,
+}
+impl Default for DeviceKind {
+    fn default() -> Self {
+        DeviceKind::Virtual
+    }
 }
 
 /// デバイス。

--- a/src/entity/device.rs
+++ b/src/entity/device.rs
@@ -32,7 +32,7 @@ pub struct DeviceSummary {
 }
 
 /// デバイスの種類。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DeviceKind {
     /// 仮想デバイス。
@@ -299,6 +299,33 @@ impl Weight {
             Weight::Relative(r) => (base as f64 * r) as u64,
         }
     }
+
+    /// 自動計算であれば true を返す。
+    #[allow(dead_code)]
+    pub(crate) fn is_auto(&self) -> bool {
+        if let Weight::Auto = self {
+            return true;
+        }
+        false
+    }
+
+    /// 絶対値の重みであれば true を返す。
+    #[allow(dead_code)]
+    pub(crate) fn is_absolute(&self) -> bool {
+        if let Weight::Absolute(_) = self {
+            return true;
+        }
+        false
+    }
+
+    /// 相対値の重みであれば true を返す。
+    #[allow(dead_code)]
+    pub(crate) fn is_relative(&self) -> bool {
+        if let Weight::Relative(_) = self {
+            return true;
+        }
+        false
+    }
 }
 impl Default for Weight {
     fn default() -> Self {
@@ -307,7 +334,7 @@ impl Default for Weight {
 }
 
 /// セグメントの割当方針。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum SegmentAllocationPolicy {
     /// 可能であれば、同じセグメント内のノード群には別々のデバイスを割り当てる。
     #[serde(rename = "SCATTER_IF_POSSIBLE")]

--- a/src/entity/object.rs
+++ b/src/entity/object.rs
@@ -25,7 +25,8 @@ impl FromStr for ObjectVersion {
 pub struct ObjectPrefix(pub String);
 
 /// メタデータオブジェクトの要約.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// `Default` は `DeleteObjectsByRangeRpc::client` などが要求する.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct ObjectSummary {
     pub id: String,

--- a/src/entity/server.rs
+++ b/src/entity/server.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, SocketAddr};
 pub type ServerId = String;
 
 /// サーバの要約情報。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ServerSummary {
     /// ID。
     pub id: ServerId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate fibers;
 extern crate fibers_rpc;
 extern crate futures;
 extern crate libc;
+extern crate protobuf_codec;
 extern crate serde;
 
 #[macro_use]
@@ -21,7 +22,10 @@ pub mod consistency;
 pub mod deadline;
 pub mod entity;
 pub mod expect;
+#[macro_use]
+mod macros;
 pub mod multiplicity;
+pub mod protobuf;
 pub mod repair;
 pub mod schema;
 pub mod time;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,65 @@
+macro_rules! impl_message_decode {
+    ($decoder:ty, $item:ty, $map:expr) => {
+        impl ::bytecodec::Decode for $decoder {
+            type Item = $item;
+
+            fn decode(&mut self, buf: &[u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+                track!(self.inner.decode(buf, eos))
+            }
+
+            fn finish_decoding(&mut self) -> ::bytecodec::Result<Self::Item> {
+                let item = track!(self.inner.finish_decoding())?;
+                $map(item)
+            }
+
+            fn is_idle(&self) -> bool {
+                self.inner.is_idle()
+            }
+
+            fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+                self.inner.requiring_bytes()
+            }
+        }
+        impl ::protobuf_codec::message::MessageDecode for $decoder {}
+    };
+}
+
+macro_rules! impl_message_encode {
+    ($encoder:ty, $item:ty, $map:expr) => {
+        impl ::bytecodec::Encode for $encoder {
+            type Item = $item;
+
+            fn encode(
+                &mut self,
+                buf: &mut [u8],
+                eos: ::bytecodec::Eos,
+            ) -> ::bytecodec::Result<usize> {
+                track!(self.inner.encode(buf, eos))
+            }
+
+            fn start_encoding(&mut self, item: Self::Item) -> ::bytecodec::Result<()> {
+                track!(self.inner.start_encoding($map(item)))
+            }
+
+            fn is_idle(&self) -> bool {
+                self.inner.is_idle()
+            }
+
+            fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+                self.inner.requiring_bytes()
+            }
+        }
+        impl ::protobuf_codec::message::MessageEncode for $encoder {}
+    };
+}
+
+macro_rules! impl_sized_message_encode {
+    ($encoder:ty, $item:ty, $map:expr) => {
+        impl_message_encode!($encoder, $item, $map);
+        impl ::bytecodec::SizedEncode for $encoder {
+            fn exact_requiring_bytes(&self) -> u64 {
+                self.inner.exact_requiring_bytes()
+            }
+        }
+    };
+}

--- a/src/protobuf/consistency.rs
+++ b/src/protobuf/consistency.rs
@@ -1,0 +1,58 @@
+//! Decoders and encoders for [libfrugalos.consistency].
+
+use protobuf_codec::field::branch::Branch4;
+use protobuf_codec::field::num::{F1, F2, F3, F4};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, MessageFieldDecoder, MessageFieldEncoder, Oneof,
+};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{Uint32Decoder, Uint32Encoder};
+use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMessageEncoder};
+
+use consistency::ReadConsistency;
+
+/// Decoder for `ReadConsistency`.
+#[derive(Debug, Default)]
+pub struct ReadConsistencyDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            MessageFieldDecoder<F1, EmptyMessageDecoder>,
+            MessageFieldDecoder<F2, EmptyMessageDecoder>,
+            MessageFieldDecoder<F3, EmptyMessageDecoder>,
+            FieldDecoder<F4, Uint32Decoder>,
+        )>,
+    >,
+}
+impl_message_decode!(ReadConsistencyDecoder, ReadConsistency, |t: _| {
+    Ok(match t {
+        Branch4::A(_) => ReadConsistency::Consistent,
+        Branch4::B(_) => ReadConsistency::Stale,
+        Branch4::C(_) => ReadConsistency::Quorum,
+        Branch4::D(n) => ReadConsistency::Subset(n as usize),
+    })
+});
+
+/// Encoder for `ReadConsistency`.
+#[derive(Debug, Default)]
+pub struct ReadConsistencyEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            MessageFieldEncoder<F1, EmptyMessageEncoder>,
+            MessageFieldEncoder<F2, EmptyMessageEncoder>,
+            MessageFieldEncoder<F3, EmptyMessageEncoder>,
+            FieldEncoder<F4, Uint32Encoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    ReadConsistencyEncoder,
+    ReadConsistency,
+    |item: Self::Item| {
+        match item {
+            ReadConsistency::Consistent => Branch4::A(()),
+            ReadConsistency::Stale => Branch4::B(()),
+            ReadConsistency::Quorum => Branch4::C(()),
+            ReadConsistency::Subset(n) => Branch4::D(n as u32),
+        }
+    }
+);

--- a/src/protobuf/consistency.rs
+++ b/src/protobuf/consistency.rs
@@ -1,4 +1,6 @@
-//! Decoders and encoders for [libfrugalos.consistency].
+//! Decoders and encoders for [`libfrugalos::consistency`](../../consistency/index.html).
+//!
+//! `package libfrugalos.protobuf.consistency`.
 
 use protobuf_codec::field::branch::Branch4;
 use protobuf_codec::field::num::{F1, F2, F3, F4};
@@ -11,13 +13,16 @@ use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMess
 
 use consistency::ReadConsistency;
 
-/// Decoder for `ReadConsistency`.
+/// Decoder for [`ReadConsistency`](../../consistency/enum.ReadConsistency.html).
 #[derive(Debug, Default)]
 pub struct ReadConsistencyDecoder {
     inner: MessageDecoder<
         Oneof<(
+            // Consistent
             MessageFieldDecoder<F1, EmptyMessageDecoder>,
+            // Stale
             MessageFieldDecoder<F2, EmptyMessageDecoder>,
+            // Quorum
             MessageFieldDecoder<F3, EmptyMessageDecoder>,
             FieldDecoder<F4, Uint32Decoder>,
         )>,
@@ -32,14 +37,18 @@ impl_message_decode!(ReadConsistencyDecoder, ReadConsistency, |t: _| {
     })
 });
 
-/// Encoder for `ReadConsistency`.
+/// Encoder for [`ReadConsistency`](../../consistency/enum.ReadConsistency.html).
 #[derive(Debug, Default)]
 pub struct ReadConsistencyEncoder {
     inner: MessageEncoder<
         Oneof<(
+            // Consistent
             MessageFieldEncoder<F1, EmptyMessageEncoder>,
+            // Stale
             MessageFieldEncoder<F2, EmptyMessageEncoder>,
+            // Quorum
             MessageFieldEncoder<F3, EmptyMessageEncoder>,
+            // Subset
             FieldEncoder<F4, Uint32Encoder>,
         )>,
     >,

--- a/src/protobuf/deadline.rs
+++ b/src/protobuf/deadline.rs
@@ -1,4 +1,6 @@
-//! Decoders and encoders for [libfrugalos.deadline].
+//! Decoders and encoders for [`libfrugalos::deadline`](../../deadline/index.html).
+//!
+//! `package libfrugalos.protobuf.deadline`.
 
 use bytecodec::{ErrorKind, Result};
 use protobuf_codec::wellknown::google::protobuf::{
@@ -7,24 +9,31 @@ use protobuf_codec::wellknown::google::protobuf::{
 use std::time::Duration;
 use trackable::error::ErrorKindExt;
 
-/// Decoder for `Deadline`.
+/// Decoder for [`Deadline`](../../deadline/struct.Deadline.html).
 // 互換性に注意: frugalos では秒で扱っている
 // https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L98
 pub type DeadlineDecoder = DurationMessageDecoder;
 
-/// Encoder for `Deadline`.
+/// Encoder for [`Deadline`](../../deadline/struct.Deadline.html).
 // 互換性に注意: frugalos では秒で扱っている
 // https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L109
 pub type DeadlineEncoder = DurationMessageEncoder;
 
-/// Decodes `Deadline`.
+/// Decodes [Deadline](../../deadline/struct.Deadline.html).
+///
+/// # Errors
+///
+/// Returns [`bytecodec::ErrorKind::InvalidInput`](../../../bytecodec/enum.ErrorKind.html#variant.InvalidInput)
+/// if an input is not a valid duration.
+///
+/// See [`bytecodec::Error`](bytecodec/enum.ErrorKind.html).
 pub fn decode_deadline(deadline: DurationMessage) -> Result<Duration> {
     track!(deadline.to_duration().ok_or_else(|| ErrorKind::InvalidInput
         .cause(format!("incorrect duration: {:?}", deadline))
         .into()))
 }
 
-/// Encodes `Deadline`.
+/// Encodes [Deadline](../../deadline/struct.Deadline.html).
 pub fn encode_deadline(deadline: Duration) -> DurationMessage {
     // FIXME: Result を返すようにする
     DurationMessage::from_duration(deadline).unwrap_or_else(|e| unreachable!("{:?}", e))

--- a/src/protobuf/deadline.rs
+++ b/src/protobuf/deadline.rs
@@ -1,0 +1,31 @@
+//! Decoders and encoders for [libfrugalos.deadline].
+
+use bytecodec::{ErrorKind, Result};
+use protobuf_codec::wellknown::google::protobuf::{
+    DurationMessage, DurationMessageDecoder, DurationMessageEncoder,
+};
+use std::time::Duration;
+use trackable::error::ErrorKindExt;
+
+/// Decoder for `Deadline`.
+// 互換性に注意: frugalos では秒で扱っている
+// https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L98
+pub type DeadlineDecoder = DurationMessageDecoder;
+
+/// Encoder for `Deadline`.
+// 互換性に注意: frugalos では秒で扱っている
+// https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L109
+pub type DeadlineEncoder = DurationMessageEncoder;
+
+/// Decodes `Deadline`.
+pub fn decode_deadline(deadline: DurationMessage) -> Result<Duration> {
+    track!(deadline.to_duration().ok_or_else(|| ErrorKind::InvalidInput
+        .cause(format!("incorrect duration: {:?}", deadline))
+        .into()))
+}
+
+/// Encodes `Deadline`.
+pub fn encode_deadline(deadline: Duration) -> DurationMessage {
+    // FIXME: Result を返すようにする
+    DurationMessage::from_duration(deadline).unwrap_or_else(|e| unreachable!("{:?}", e))
+}

--- a/src/protobuf/deadline.rs
+++ b/src/protobuf/deadline.rs
@@ -38,3 +38,24 @@ pub fn encode_deadline(deadline: Duration) -> DurationMessage {
     // FIXME: Result を返すようにする
     DurationMessage::from_duration(deadline).unwrap_or_else(|e| unreachable!("{:?}", e))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trackable::result::TestResult;
+
+    #[test]
+    fn decode_works() -> TestResult {
+        let duration = track!(DurationMessage::new(5, 0))?;
+        let message = track!(decode_deadline(duration))?;
+        assert_eq!(Duration::from_secs(5), message);
+        Ok(())
+    }
+
+    #[test]
+    fn encode_works() {
+        let duration = Duration::from_secs(5);
+        let message = encode_deadline(duration);
+        assert_eq!(DurationMessage::new(5, 0).unwrap(), message);
+    }
+}

--- a/src/protobuf/entity/bucket.rs
+++ b/src/protobuf/entity/bucket.rs
@@ -1,0 +1,316 @@
+//! Decoders and encoders for [libfrugalos.entity.bucket].
+
+use bytecodec::ErrorKind;
+use protobuf_codec::field::branch::Branch3;
+use protobuf_codec::field::num::{F1, F2, F3, F4, F5, F6};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, Fields, MaybeDefault, MessageFieldDecoder, MessageFieldEncoder,
+    Oneof,
+};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{StringDecoder, StringEncoder, Uint32Decoder, Uint32Encoder};
+
+use entity::bucket::{
+    Bucket, BucketId, BucketKind, BucketSummary, DispersedBucket, MetadataBucket, ReplicatedBucket,
+};
+use entity::device::DeviceId;
+use protobuf::entity::device::{DeviceIdDecoder, DeviceIdEncoder};
+
+/// Decoder for `BucketId`.
+pub type BucketIdDecoder = StringDecoder;
+
+/// Encoder for `BucketId`.
+pub type BucketIdEncoder = StringEncoder;
+
+/// Decoder for `BucketKind`.
+type BucketKindDecoder = Uint32Decoder;
+
+/// Encoder for `BucketKind`.
+type BucketKindEncoder = Uint32Encoder;
+
+/// Decoder for `SegmentCount`.
+type SegmentCountDecoder = Uint32Decoder;
+
+/// Encoder for `SegmentCount`.
+type SegmentCountEncoder = Uint32Encoder;
+
+/// Decoder for `SequenceNumber`.
+type SequenceNumberDecoder = Uint32Decoder;
+
+/// Encoder for `SequenceNumber`.
+type SequenceNumberEncoder = Uint32Encoder;
+
+/// Decoder for `TolerableFaults`.
+type TolerableFaultsDecoder = Uint32Decoder;
+
+/// Encoder for `TolerableFaults`.
+type TolerableFaultsEncoder = Uint32Encoder;
+
+/// Decoder for `DataFragmentCount`.
+type DataFragmentCountDecoder = Uint32Decoder;
+
+/// Encoder for `DataFragmentCount`.
+type DataFragmentCountEncoder = Uint32Encoder;
+
+/// Decoder for `BucketSummary`.
+#[derive(Debug, Default)]
+pub struct BucketSummaryDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, BucketKindDecoder>>,
+            MaybeDefault<FieldDecoder<F3, DeviceIdDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(BucketSummaryDecoder, BucketSummary, |t: (
+    BucketId,
+    _,
+    DeviceId,
+)| {
+    Ok(BucketSummary {
+        id: t.0,
+        kind: match t.1 {
+            0 => BucketKind::Metadata,
+            1 => BucketKind::Replicated,
+            2 => BucketKind::Dispersed,
+            n => track_panic!(ErrorKind::InvalidInput, "Unknown bucket kind: {}", n),
+        },
+        device: t.2,
+    })
+});
+
+/// Encoder for `BucketSummary`.
+#[derive(Debug, Default)]
+pub struct BucketSummaryEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, BucketKindEncoder>,
+            FieldEncoder<F3, DeviceIdEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(BucketSummaryEncoder, BucketSummary, |item: Self::Item| {
+    let kind = match item.kind {
+        BucketKind::Metadata => 0,
+        BucketKind::Replicated => 1,
+        BucketKind::Dispersed => 2,
+    };
+    (item.id, kind, item.device)
+});
+
+/// Decoder for `Bucket`.
+#[derive(Debug, Default)]
+pub struct BucketDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            MessageFieldDecoder<F1, MetadataBucketDecoder>,
+            MessageFieldDecoder<F2, ReplicatedBucketDecoder>,
+            MessageFieldDecoder<F3, DispersedBucketDecoder>,
+        )>,
+    >,
+}
+
+impl_message_decode!(BucketDecoder, Bucket, |t: _| {
+    Ok(match t {
+        Branch3::A(bucket) => Bucket::Metadata(bucket),
+        Branch3::B(bucket) => Bucket::Replicated(bucket),
+        Branch3::C(bucket) => Bucket::Dispersed(bucket),
+    })
+});
+
+/// Encoder for `Bucket`.
+#[derive(Debug, Default)]
+pub struct BucketEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            MessageFieldEncoder<F1, MetadataBucketEncoder>,
+            MessageFieldEncoder<F2, ReplicatedBucketEncoder>,
+            MessageFieldEncoder<F3, DispersedBucketEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(BucketEncoder, Bucket, |item: Self::Item| match item {
+    Bucket::Metadata(bucket) => Branch3::A(bucket),
+    Bucket::Replicated(bucket) => Branch3::B(bucket),
+    Bucket::Dispersed(bucket) => Branch3::C(bucket),
+});
+
+/// Decoder for `MetadataBucket`.
+#[derive(Debug, Default)]
+pub struct MetadataBucketDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, SequenceNumberDecoder>>,
+            MaybeDefault<FieldDecoder<F3, DeviceIdDecoder>>,
+            MaybeDefault<FieldDecoder<F4, SegmentCountDecoder>>,
+            MaybeDefault<FieldDecoder<F5, TolerableFaultsDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(MetadataBucketDecoder, MetadataBucket, |t: (
+    BucketId,
+    _,
+    DeviceId,
+    _,
+    _,
+)| {
+    Ok(MetadataBucket {
+        id: t.0.clone(),
+        seqno: t.1,
+        device: t.2.clone(),
+        segment_count: t.3,
+        tolerable_faults: t.4,
+    })
+});
+
+/// Encoder for `MetadataBucket`.
+#[derive(Debug, Default)]
+pub struct MetadataBucketEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, SequenceNumberEncoder>,
+            FieldEncoder<F3, DeviceIdEncoder>,
+            FieldEncoder<F4, SegmentCountEncoder>,
+            FieldEncoder<F5, TolerableFaultsEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(MetadataBucketEncoder, MetadataBucket, |item: Self::Item| {
+    (
+        item.id,
+        item.seqno,
+        item.device,
+        item.segment_count,
+        item.tolerable_faults,
+    )
+});
+
+/// Decoder for `ReplicatedBucket`.
+#[derive(Debug, Default)]
+pub struct ReplicatedBucketDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, SequenceNumberDecoder>>,
+            MaybeDefault<FieldDecoder<F3, DeviceIdDecoder>>,
+            MaybeDefault<FieldDecoder<F4, SegmentCountDecoder>>,
+            MaybeDefault<FieldDecoder<F5, TolerableFaultsDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(ReplicatedBucketDecoder, ReplicatedBucket, |t: (
+    BucketId,
+    _,
+    DeviceId,
+    _,
+    _,
+)| {
+    Ok(ReplicatedBucket {
+        id: t.0.clone(),
+        seqno: t.1,
+        device: t.2.clone(),
+        segment_count: t.3,
+        tolerable_faults: t.4,
+    })
+});
+
+/// Encoder for `ReplicatedBucket`.
+#[derive(Debug, Default)]
+pub struct ReplicatedBucketEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, SequenceNumberEncoder>,
+            FieldEncoder<F3, DeviceIdEncoder>,
+            FieldEncoder<F4, SegmentCountEncoder>,
+            FieldEncoder<F5, TolerableFaultsEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(
+    ReplicatedBucketEncoder,
+    ReplicatedBucket,
+    |item: Self::Item| {
+        (
+            item.id,
+            item.seqno,
+            item.device,
+            item.segment_count,
+            item.tolerable_faults,
+        )
+    }
+);
+
+/// Decoder for `DispersedBucket`.
+#[derive(Debug, Default)]
+pub struct DispersedBucketDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, SequenceNumberDecoder>>,
+            MaybeDefault<FieldDecoder<F3, DeviceIdDecoder>>,
+            MaybeDefault<FieldDecoder<F4, SegmentCountDecoder>>,
+            MaybeDefault<FieldDecoder<F5, TolerableFaultsDecoder>>,
+            MaybeDefault<FieldDecoder<F6, DataFragmentCountDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(DispersedBucketDecoder, DispersedBucket, |t: (
+    BucketId,
+    _,
+    DeviceId,
+    _,
+    _,
+    _,
+)| {
+    Ok(DispersedBucket {
+        id: t.0.clone(),
+        seqno: t.1,
+        device: t.2.clone(),
+        segment_count: t.3,
+        tolerable_faults: t.4,
+        data_fragment_count: t.5,
+    })
+});
+
+/// Encoder for `DispersedBucket`.
+#[derive(Debug, Default)]
+pub struct DispersedBucketEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, SequenceNumberEncoder>,
+            FieldEncoder<F3, DeviceIdEncoder>,
+            FieldEncoder<F4, SegmentCountEncoder>,
+            FieldEncoder<F5, TolerableFaultsEncoder>,
+            FieldEncoder<F6, DataFragmentCountEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(
+    DispersedBucketEncoder,
+    DispersedBucket,
+    |item: Self::Item| {
+        (
+            item.id,
+            item.seqno,
+            item.device,
+            item.segment_count,
+            item.tolerable_faults,
+            item.data_fragment_count,
+        )
+    }
+);

--- a/src/protobuf/entity/bucket.rs
+++ b/src/protobuf/entity/bucket.rs
@@ -1,4 +1,6 @@
-//! Decoders and encoders for [libfrugalos.entity.bucket].
+//! Decoders and encoders for [`libfrugalos::entity::bucket`](../../entity/bucket/index.html).
+//!
+//! `package libfrugalos.protobuf.entity.bucket`.
 
 use bytecodec::ErrorKind;
 use protobuf_codec::field::branch::Branch3;

--- a/src/protobuf/entity/device.rs
+++ b/src/protobuf/entity/device.rs
@@ -1,0 +1,404 @@
+//! Decoders and encoders for [libfrugalos.entity.device].
+
+use bytecodec::combinator::PreEncode;
+use bytecodec::{ErrorKind, Result};
+use protobuf_codec::field::branch::Branch3;
+use protobuf_codec::field::num::{F1, F2, F3, F4, F5, F6};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, Fields, MaybeDefault, MessageFieldDecoder, MessageFieldEncoder,
+    Oneof, Optional, Repeated,
+};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{
+    DoubleDecoder, DoubleEncoder, StringDecoder, StringEncoder, Uint32Decoder, Uint32Encoder,
+    Uint64Decoder, Uint64Encoder,
+};
+use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMessageEncoder};
+use std::borrow::ToOwned;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use trackable::error::ErrorKindExt;
+
+use entity::device::{
+    Device, DeviceId, DeviceKind, DeviceSummary, FileDevice, MemoryDevice, SegmentAllocationPolicy,
+    VirtualDevice, Weight,
+};
+use entity::server::ServerId;
+use protobuf::entity::server::{ServerIdDecoder, ServerIdEncoder};
+
+/// Decoder for `Capacity`.
+type CapacityDecoder = Uint64Decoder;
+
+/// Encoder for `Capacity`.
+type CapacityEncoder = Uint64Encoder;
+
+/// Decoder for `DeviceId`.
+pub type DeviceIdDecoder = StringDecoder;
+
+/// Encoder for `DeviceId`.
+pub type DeviceIdEncoder = StringEncoder;
+
+/// Decoder for `DeviceKind`.
+type DeviceKindDecoder = Uint32Decoder;
+
+/// Encoder for `DeviceKind`.
+type DeviceKindEncoder = Uint32Encoder;
+
+/// Decoder for `Path`.
+pub type PathDecoder = StringDecoder;
+
+/// Encoder for `Path`.
+pub type PathEncoder = StringEncoder;
+
+/// Decoder for `SegmentAllocationPolicy`.
+type SegmentAllocationPolicyDecoder = Uint32Decoder;
+
+/// Encoder for `SegmentAllocationPolicy`.
+type SegmentAllocationPolicyEncoder = Uint32Encoder;
+
+/// Decoder for `SequenceNumber`.
+type SequenceNumberDecoder = Uint32Decoder;
+
+/// Encoder for `SequenceNumber`.
+type SequenceNumberEncoder = Uint32Encoder;
+
+/// Decoder for `DeviceSummary`.
+#[derive(Debug, Default)]
+pub struct DeviceSummaryDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, DeviceIdDecoder>>,
+            Optional<FieldDecoder<F2, ServerIdDecoder>>,
+            MaybeDefault<FieldDecoder<F3, DeviceKindDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(DeviceSummaryDecoder, DeviceSummary, |t: (
+    DeviceId,
+    Option<ServerId>,
+    _,
+)| {
+    Ok(DeviceSummary {
+        id: t.0.clone(),
+        server: t.1.clone(),
+        kind: match t.2 {
+            0 => DeviceKind::Virtual,
+            1 => DeviceKind::Memory,
+            2 => DeviceKind::File,
+            n => track_panic!(ErrorKind::InvalidInput, "Unknown device kind: {}", n),
+        },
+    })
+});
+
+/// Encoder for `DeviceSummary`.
+#[derive(Debug, Default)]
+pub struct DeviceSummaryEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, DeviceIdEncoder>,
+            Optional<FieldEncoder<F2, ServerIdEncoder>>,
+            FieldEncoder<F3, DeviceKindEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(DeviceSummaryEncoder, DeviceSummary, |item: Self::Item| {
+    let kind = match item.kind {
+        DeviceKind::Virtual => 0,
+        DeviceKind::Memory => 1,
+        DeviceKind::File => 2,
+    };
+    (item.id, item.server, kind)
+});
+
+/// Decoder for `Device`.
+#[derive(Debug, Default)]
+pub struct DeviceDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            MessageFieldDecoder<F1, VirtualDeviceDecoder>,
+            MessageFieldDecoder<F2, MemoryDeviceDecoder>,
+            MessageFieldDecoder<F3, FileDeviceDecoder>,
+        )>,
+    >,
+}
+
+impl_message_decode!(DeviceDecoder, Device, |t: _| {
+    Ok(match t {
+        Branch3::A(device) => Device::Virtual(device),
+        Branch3::B(device) => Device::Memory(device),
+        Branch3::C(device) => Device::File(device),
+    })
+});
+
+/// Encoder for `Device`.
+#[derive(Debug, Default)]
+pub struct DeviceEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            MessageFieldEncoder<F1, PreEncode<VirtualDeviceEncoder>>,
+            MessageFieldEncoder<F2, MemoryDeviceEncoder>,
+            MessageFieldEncoder<F3, FileDeviceEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(DeviceEncoder, Device, |item: Self::Item| match item {
+    Device::Virtual(device) => Branch3::A(device),
+    Device::Memory(device) => Branch3::B(device),
+    Device::File(device) => Branch3::C(device),
+});
+
+/// Decoder for `Weight`.
+#[derive(Debug, Default)]
+pub struct WeightDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            MessageFieldDecoder<F1, EmptyMessageDecoder>,
+            FieldDecoder<F2, Uint64Decoder>,
+            FieldDecoder<F3, DoubleDecoder>,
+        )>,
+    >,
+}
+
+impl_message_decode!(WeightDecoder, Weight, |t: _| {
+    Ok(match t {
+        Branch3::A(_) => Weight::Auto,
+        Branch3::B(n) => Weight::Absolute(n),
+        Branch3::C(n) => Weight::Relative(n),
+    })
+});
+
+/// Encoder for `Weight`.
+#[derive(Debug, Default)]
+pub struct WeightEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            MessageFieldEncoder<F1, EmptyMessageEncoder>,
+            FieldEncoder<F2, Uint64Encoder>,
+            FieldEncoder<F3, DoubleEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(WeightEncoder, Weight, |item: Self::Item| match item {
+    Weight::Auto => Branch3::A(()),
+    Weight::Absolute(n) => Branch3::B(n),
+    Weight::Relative(n) => Branch3::C(n),
+});
+
+fn decode_segment_allocation_policy(x: u32) -> Result<SegmentAllocationPolicy> {
+    Ok(match x {
+        0 => SegmentAllocationPolicy::ScatterIfPossible,
+        1 => SegmentAllocationPolicy::Scatter,
+        2 => SegmentAllocationPolicy::Neutral,
+        3 => SegmentAllocationPolicy::Gather,
+        4 => SegmentAllocationPolicy::AsEvenAsPossible,
+        n => track_panic!(
+            ErrorKind::InvalidInput,
+            "Unknown SegmentAllocationPolicy: {}",
+            n
+        ),
+    })
+}
+
+fn encode_segment_allocation_policy(policy: SegmentAllocationPolicy) -> u32 {
+    match policy {
+        SegmentAllocationPolicy::ScatterIfPossible => 0,
+        SegmentAllocationPolicy::Scatter => 1,
+        SegmentAllocationPolicy::Neutral => 2,
+        SegmentAllocationPolicy::Gather => 3,
+        SegmentAllocationPolicy::AsEvenAsPossible => 4,
+    }
+}
+
+/// Decoder for `VirtualDevice`.
+#[derive(Debug, Default)]
+pub struct VirtualDeviceDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, DeviceIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, SequenceNumberDecoder>>,
+            MaybeDefault<MessageFieldDecoder<F3, WeightDecoder>>,
+            Repeated<FieldDecoder<F4, DeviceIdDecoder>, Vec<DeviceId>>,
+            MaybeDefault<FieldDecoder<F5, SegmentAllocationPolicyDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(VirtualDeviceDecoder, VirtualDevice, |t: (
+    String,
+    _,
+    Weight,
+    Vec<_>,
+    _,
+)| {
+    let policy = track!(decode_segment_allocation_policy(t.4))?;
+    Ok(VirtualDevice {
+        id: t.0.clone(),
+        seqno: t.1,
+        weight: t.2.clone(),
+        children: t.3.into_iter().collect::<BTreeSet<_>>(),
+        policy,
+    })
+});
+
+/// Encoder for `VirtualDevice`.
+#[derive(Debug, Default)]
+pub struct VirtualDeviceEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, DeviceIdEncoder>,
+            FieldEncoder<F2, SequenceNumberEncoder>,
+            MessageFieldEncoder<F3, WeightEncoder>,
+            Repeated<FieldEncoder<F4, DeviceIdEncoder>, Vec<DeviceId>>,
+            FieldEncoder<F5, SegmentAllocationPolicyEncoder>,
+        )>,
+    >,
+}
+
+impl_message_encode!(VirtualDeviceEncoder, VirtualDevice, |item: Self::Item| {
+    (
+        item.id,
+        item.seqno,
+        item.weight,
+        item.children.into_iter().collect::<Vec<_>>(),
+        encode_segment_allocation_policy(item.policy),
+    )
+});
+
+/// Decoder for `MemoryDevice`.
+#[derive(Debug, Default)]
+pub struct MemoryDeviceDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, DeviceIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, SequenceNumberDecoder>>,
+            MaybeDefault<MessageFieldDecoder<F3, WeightDecoder>>,
+            MaybeDefault<FieldDecoder<F4, ServerIdDecoder>>,
+            MaybeDefault<FieldDecoder<F5, CapacityDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(MemoryDeviceDecoder, MemoryDevice, |t: (
+    DeviceId,
+    _,
+    Weight,
+    ServerId,
+    _,
+)| {
+    Ok(MemoryDevice {
+        id: t.0.clone(),
+        seqno: t.1,
+        weight: t.2.clone(),
+        server: t.3.clone(),
+        capacity: t.4,
+    })
+});
+
+/// Encoder for `MemoryDevice`.
+#[derive(Debug, Default)]
+pub struct MemoryDeviceEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, DeviceIdEncoder>,
+            FieldEncoder<F2, SequenceNumberEncoder>,
+            MessageFieldEncoder<F3, WeightEncoder>,
+            FieldEncoder<F4, ServerIdEncoder>,
+            FieldEncoder<F5, CapacityEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(MemoryDeviceEncoder, MemoryDevice, |item: Self::Item| {
+    (item.id, item.seqno, item.weight, item.server, item.capacity)
+});
+
+/// Decoder for `FileDevice`.
+#[derive(Debug, Default)]
+pub struct FileDeviceDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, DeviceIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, SequenceNumberDecoder>>,
+            MaybeDefault<MessageFieldDecoder<F3, WeightDecoder>>,
+            MaybeDefault<FieldDecoder<F4, ServerIdDecoder>>,
+            MaybeDefault<FieldDecoder<F5, CapacityDecoder>>,
+            // パスは valid な UTF-8 に制限してしまう
+            MaybeDefault<FieldDecoder<F6, PathDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(FileDeviceDecoder, FileDevice, |t: (
+    DeviceId,
+    _,
+    Weight,
+    ServerId,
+    _,
+    String,
+)| {
+    Ok(FileDevice {
+        id: t.0.clone(),
+        seqno: t.1,
+        weight: t.2.clone(),
+        server: t.3.clone(),
+        capacity: t.4,
+        filepath: PathBuf::from(t.5),
+    })
+});
+
+/// Encoder for `FileDevice`.
+#[derive(Debug, Default)]
+pub struct FileDeviceEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, DeviceIdEncoder>,
+            FieldEncoder<F2, SequenceNumberEncoder>,
+            MessageFieldEncoder<F3, WeightEncoder>,
+            FieldEncoder<F4, ServerIdEncoder>,
+            FieldEncoder<F5, CapacityEncoder>,
+            FieldEncoder<F6, PathEncoder>,
+        )>,
+    >,
+}
+// `FileDeviceEncoder` はバリデーションが必要なのでマクロを使わずに実装する
+impl ::bytecodec::Encode for FileDeviceEncoder {
+    type Item = FileDevice;
+
+    fn encode(&mut self, buf: &mut [u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.encode(buf, eos))
+    }
+
+    fn start_encoding(&mut self, item: Self::Item) -> ::bytecodec::Result<()> {
+        let filepath = track!(item
+            .filepath
+            .to_str()
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| ErrorKind::InvalidInput.cause("filepath is not a valid UTF-8")))?;
+        track!(self.inner.start_encoding((
+            item.id,
+            item.seqno,
+            item.weight,
+            item.server,
+            item.capacity,
+            filepath,
+        )))
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl ::protobuf_codec::message::MessageEncode for FileDeviceEncoder {}
+impl ::bytecodec::SizedEncode for FileDeviceEncoder {
+    fn exact_requiring_bytes(&self) -> u64 {
+        self.inner.exact_requiring_bytes()
+    }
+}

--- a/src/protobuf/entity/device.rs
+++ b/src/protobuf/entity/device.rs
@@ -1,4 +1,6 @@
-//! Decoders and encoders for [libfrugalos.entity.device].
+//! Decoders and encoders for [`libfrugalos::entity::device`](../../entity/device/index.html).
+//!
+//! `package libfrugalos.protobuf.entity.device`.
 
 use bytecodec::combinator::PreEncode;
 use bytecodec::{ErrorKind, Result};

--- a/src/protobuf/entity/mod.rs
+++ b/src/protobuf/entity/mod.rs
@@ -1,4 +1,6 @@
-//! Encoders and decoders of Protocol Buffers.
+//! Decoders and encoders for [`libfrugalos::entity`](../../entity/index.html).
+//!
+//! `package libfrugalos.protobuf.entity`.
 
 pub mod bucket;
 pub mod device;

--- a/src/protobuf/entity/mod.rs
+++ b/src/protobuf/entity/mod.rs
@@ -1,0 +1,7 @@
+//! Encoders and decoders of Protocol Buffers.
+
+pub mod bucket;
+pub mod device;
+pub mod node;
+pub mod object;
+pub mod server;

--- a/src/protobuf/entity/node.rs
+++ b/src/protobuf/entity/node.rs
@@ -1,0 +1,47 @@
+//! Decoders and encoders for [libfrugalos.entity].
+
+use protobuf_codec::field::num::{F1, F2};
+use protobuf_codec::field::{FieldDecoder, FieldEncoder, Fields, MaybeDefault};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{StringDecoder, StringEncoder};
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use entity::node::RemoteNodeId;
+
+/// Decoder for [LocalNodeId].
+pub type LocalNodeIdDecoder = StringDecoder;
+
+/// Encoder for [LocalNodeId].
+pub type LocalNodeIdEncoder = StringEncoder;
+
+/// Decoder for `RemoteNodeId`.
+#[derive(Debug, Default)]
+pub struct RemoteNodeIdDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, StringDecoder>>,
+            MaybeDefault<FieldDecoder<F2, StringDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(RemoteNodeIdDecoder, RemoteNodeId, |t: (String, String,)| {
+    let addr = track_any_err!(SocketAddr::from_str(&t.0))?;
+    Ok((addr, t.1))
+});
+
+/// Encoder for `RemoteNodeId`.
+#[derive(Debug, Default)]
+pub struct RemoteNodeIdEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, StringEncoder>,
+            FieldEncoder<F2, StringEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(RemoteNodeIdEncoder, RemoteNodeId, |item: Self::Item| {
+    (item.0.to_string(), item.1)
+});

--- a/src/protobuf/entity/node.rs
+++ b/src/protobuf/entity/node.rs
@@ -11,13 +11,13 @@ use std::str::FromStr;
 
 use entity::node::RemoteNodeId;
 
-/// Decoder for [LocalNodeId].
+/// Decoder for [`LocalNodeId`](../../../entity/node/type.LocalNodeId.html).
 pub type LocalNodeIdDecoder = StringDecoder;
 
-/// Encoder for [LocalNodeId].
+/// Encoder for [`LocalNodeId`](../../../entity/node/type.LocalNodeId.html).
 pub type LocalNodeIdEncoder = StringEncoder;
 
-/// Decoder for `RemoteNodeId`.
+/// Decoder for [`RemoteNodeId`](../../../entity/node/type.RemoteNodeId.html).
 #[derive(Debug, Default)]
 pub struct RemoteNodeIdDecoder {
     inner: MessageDecoder<
@@ -33,7 +33,7 @@ impl_message_decode!(RemoteNodeIdDecoder, RemoteNodeId, |t: (String, String,)| {
     Ok((addr, t.1))
 });
 
-/// Encoder for `RemoteNodeId`.
+/// Encoder for [`RemoteNodeId`](../../../entity/node/type.RemoteNodeId.html).
 #[derive(Debug, Default)]
 pub struct RemoteNodeIdEncoder {
     inner: MessageEncoder<

--- a/src/protobuf/entity/node.rs
+++ b/src/protobuf/entity/node.rs
@@ -1,4 +1,6 @@
-//! Decoders and encoders for [libfrugalos.entity].
+//! Decoders and encoders for [`libfrugalos::entity::node`](../../entity/node/index.html).
+//!
+//! `package libfrugalos.protobuf.entity.node`.
 
 use protobuf_codec::field::num::{F1, F2};
 use protobuf_codec::field::{FieldDecoder, FieldEncoder, Fields, MaybeDefault};

--- a/src/protobuf/entity/object.rs
+++ b/src/protobuf/entity/object.rs
@@ -1,4 +1,6 @@
-//! Decoders and encoders for [libfrugalos.entity.object].
+//! Decoders and encoders for [`libfrugalos::entity::object`](../../entity/object/index.html).
+//!
+//! `package libfrugalos.protobuf.entity.object`.
 
 use protobuf_codec::field::num::{F1, F2, F3};
 use protobuf_codec::field::{

--- a/src/protobuf/entity/object.rs
+++ b/src/protobuf/entity/object.rs
@@ -1,0 +1,236 @@
+//! Decoders and encoders for [libfrugalos.entity.object].
+
+use protobuf_codec::field::num::{F1, F2, F3};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, Fields, MaybeDefault, PackedFieldDecoder, PackedFieldEncoder,
+};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{
+    BoolDecoder, BoolEncoder, BytesDecoder, BytesEncoder, StringDecoder, StringEncoder,
+    Uint32Decoder, Uint32Encoder, Uint64Decoder, Uint64Encoder,
+};
+use std::ops::Range;
+
+use entity::object::{
+    DeleteObjectsByPrefixSummary, FragmentsSummary, Metadata, ObjectPrefix, ObjectSummary,
+    ObjectVersion,
+};
+
+/// Decoder for `ObjectId`.
+pub type ObjectIdDecoder = StringDecoder;
+
+/// Encoder for `ObjectId`.
+pub type ObjectIdEncoder = StringEncoder;
+
+/// Decoder for `ObjectVersion`.
+pub type ObjectVersionDecoder = Uint64Decoder;
+
+/// Encoder for `ObjectVersion`.
+pub type ObjectVersionEncoder = Uint64Encoder;
+
+/// Decoder for `ObjectVersion`s.
+// 互換性に注意
+// https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L185
+#[derive(Debug, Default)]
+pub struct ObjectVersionsDecoder {
+    inner: MessageDecoder<PackedFieldDecoder<F1, Uint64Decoder, Vec<u64>>>,
+}
+impl_message_decode!(ObjectVersionsDecoder, Vec<u64>, |t: _| { Ok(t) });
+
+/// Encoder for `ObjectVersion`s.
+// 互換性に注意
+// https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L191
+#[derive(Debug, Default)]
+pub struct ObjectVersionsEncoder {
+    inner: MessageEncoder<PackedFieldEncoder<F1, Uint64Encoder, Vec<u64>>>,
+}
+impl_message_encode!(ObjectVersionsEncoder, Vec<u64>, |item: Self::Item| item);
+
+/// Decoder for `ObjectRange`.
+#[derive(Debug, Default)]
+pub struct ObjectRangeDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
+            MaybeDefault<FieldDecoder<F2, ObjectVersionDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(ObjectRangeDecoder, Range<ObjectVersion>, |t: (u64, u64)| {
+    Ok(Range {
+        start: ObjectVersion(t.0),
+        end: ObjectVersion(t.1),
+    })
+});
+
+/// Encoder for `ObjectRange`.
+#[derive(Debug, Default)]
+pub struct ObjectRangeEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, ObjectVersionEncoder>,
+            FieldEncoder<F2, ObjectVersionEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(
+    ObjectRangeEncoder,
+    Range<ObjectVersion>,
+    |item: Self::Item| { (item.start.0, item.end.0) }
+);
+
+/// Decoder for `ObjectSummary`.
+#[derive(Debug, Default)]
+pub struct ObjectSummaryDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, ObjectIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, ObjectVersionDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(ObjectSummaryDecoder, ObjectSummary, |t: (_, u64)| {
+    Ok(ObjectSummary {
+        id: t.0,
+        version: ObjectVersion(t.1),
+    })
+});
+
+/// Encoder for `ObjectSummary`.
+#[derive(Debug, Default)]
+pub struct ObjectSummaryEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, ObjectIdEncoder>,
+            FieldEncoder<F2, ObjectVersionEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(ObjectSummaryEncoder, ObjectSummary, |item: Self::Item| {
+    (item.id, item.version.0)
+});
+
+/// Decoder for `ObjectPrefix`.
+#[derive(Debug, Default)]
+pub struct ObjectPrefixDecoder {
+    inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, StringDecoder>>>,
+}
+
+impl_message_decode!(ObjectPrefixDecoder, ObjectPrefix, |t: _| {
+    Ok(ObjectPrefix(t))
+});
+
+/// Encoder for `ObjectPrefix`.
+#[derive(Debug, Default)]
+pub struct ObjectPrefixEncoder {
+    inner: MessageEncoder<FieldEncoder<F1, StringEncoder>>,
+}
+
+impl_sized_message_encode!(ObjectPrefixEncoder, ObjectPrefix, |item: Self::Item| {
+    item.0
+});
+
+/// Decoder for `DeleteObjectsByPrefixSummary`.
+#[derive(Debug, Default)]
+pub struct DeleteObjectsByPrefixSummaryDecoder {
+    inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, Uint64Decoder>>>,
+}
+
+impl_message_decode!(
+    DeleteObjectsByPrefixSummaryDecoder,
+    DeleteObjectsByPrefixSummary,
+    |total: _| { Ok(DeleteObjectsByPrefixSummary { total }) }
+);
+
+/// Encoder for `DeleteObjectsByPrefixSummary`.
+#[derive(Debug, Default)]
+pub struct DeleteObjectsByPrefixSummaryEncoder {
+    inner: MessageEncoder<FieldEncoder<F1, Uint64Encoder>>,
+}
+
+impl_sized_message_encode!(
+    DeleteObjectsByPrefixSummaryEncoder,
+    DeleteObjectsByPrefixSummary,
+    |item: Self::Item| { item.total }
+);
+
+/// Decoder for `Metadata`.
+#[derive(Debug, Default)]
+pub struct MetadataDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
+            MaybeDefault<FieldDecoder<F2, BytesDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(MetadataDecoder, Metadata, |t: (_, _)| {
+    Ok(Metadata {
+        version: ObjectVersion(t.0),
+        data: t.1,
+    })
+});
+
+/// Encoder for `Metadata`.
+#[derive(Debug, Default)]
+pub struct MetadataEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, ObjectVersionEncoder>,
+            FieldEncoder<F2, BytesEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(MetadataEncoder, Metadata, |item: Self::Item| {
+    (item.version.0, item.data)
+});
+
+/// Decoder for `FragmentsSummary`.
+#[derive(Debug, Default)]
+pub struct FragmentsSummaryDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BoolDecoder>>,
+            MaybeDefault<FieldDecoder<F2, Uint32Decoder>>,
+            MaybeDefault<FieldDecoder<F3, Uint32Decoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(FragmentsSummaryDecoder, FragmentsSummary, |t: (_, _, _)| {
+    Ok(FragmentsSummary {
+        is_corrupted: t.0,
+        found_total: t.1 as u8,
+        lost_total: t.2 as u8,
+    })
+});
+
+/// Encoder for `FragmentsSummary`.
+#[derive(Debug, Default)]
+pub struct FragmentsSummaryEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BoolEncoder>,
+            FieldEncoder<F2, Uint32Encoder>,
+            FieldEncoder<F3, Uint32Encoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(
+    FragmentsSummaryEncoder,
+    FragmentsSummary,
+    |item: Self::Item| {
+        (
+            item.is_corrupted,
+            item.found_total as u32,
+            item.lost_total as u32,
+        )
+    }
+);

--- a/src/protobuf/entity/object.rs
+++ b/src/protobuf/entity/object.rs
@@ -18,19 +18,19 @@ use entity::object::{
     ObjectVersion,
 };
 
-/// Decoder for `ObjectId`.
+/// Decoder for [`ObjectId`](../../../entity/object/type.ObjectId.html).
 pub type ObjectIdDecoder = StringDecoder;
 
-/// Encoder for `ObjectId`.
+/// Encoder for [`ObjectId`](../../../entity/object/type.ObjectId.html).
 pub type ObjectIdEncoder = StringEncoder;
 
-/// Decoder for `ObjectVersion`.
+/// Decoder for [`ObjectVersion`](../../../entity/object/struct.ObjectVersion.html).
 pub type ObjectVersionDecoder = Uint64Decoder;
 
-/// Encoder for `ObjectVersion`.
+/// Encoder for [`ObjectVersion`](../../../entity/object/struct.ObjectVersion.html).
 pub type ObjectVersionEncoder = Uint64Encoder;
 
-/// Decoder for `ObjectVersion`s.
+/// Decoder for [`ObjectVersion`](../../../entity/object/struct.ObjectVersion.html)s.
 // 互換性に注意
 // https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L185
 #[derive(Debug, Default)]
@@ -39,7 +39,7 @@ pub struct ObjectVersionsDecoder {
 }
 impl_message_decode!(ObjectVersionsDecoder, Vec<u64>, |t: _| { Ok(t) });
 
-/// Encoder for `ObjectVersion`s.
+/// Encoder for [`ObjectVersion`](../../../entity/object/struct.ObjectVersion.html)s.
 // 互換性に注意
 // https://github.com/frugalos/frugalos/blob/346b56c23a0055f160da385668ce163ee8ff6e60/frugalos_mds/src/protobuf.rs#L191
 #[derive(Debug, Default)]
@@ -48,7 +48,7 @@ pub struct ObjectVersionsEncoder {
 }
 impl_message_encode!(ObjectVersionsEncoder, Vec<u64>, |item: Self::Item| item);
 
-/// Decoder for `ObjectRange`.
+/// Decoder for [`ObjectRange`](../../../entity/object/struct.ObjectRange.html).
 #[derive(Debug, Default)]
 pub struct ObjectRangeDecoder {
     inner: MessageDecoder<
@@ -66,7 +66,7 @@ impl_message_decode!(ObjectRangeDecoder, Range<ObjectVersion>, |t: (u64, u64)| {
     })
 });
 
-/// Encoder for `ObjectRange`.
+/// Encoder for [`ObjectRange`](../../../entity/object/struct.ObjectRange.html).
 #[derive(Debug, Default)]
 pub struct ObjectRangeEncoder {
     inner: MessageEncoder<
@@ -83,7 +83,7 @@ impl_sized_message_encode!(
     |item: Self::Item| { (item.start.0, item.end.0) }
 );
 
-/// Decoder for `ObjectSummary`.
+/// Decoder for [`ObjectSummary`](../../../entity/object/struct.ObjectSummary.html).
 #[derive(Debug, Default)]
 pub struct ObjectSummaryDecoder {
     inner: MessageDecoder<
@@ -101,7 +101,7 @@ impl_message_decode!(ObjectSummaryDecoder, ObjectSummary, |t: (_, u64)| {
     })
 });
 
-/// Encoder for `ObjectSummary`.
+/// Encoder for [`ObjectSummary`](../../../entity/object/struct.ObjectSummary.html).
 #[derive(Debug, Default)]
 pub struct ObjectSummaryEncoder {
     inner: MessageEncoder<
@@ -116,7 +116,7 @@ impl_sized_message_encode!(ObjectSummaryEncoder, ObjectSummary, |item: Self::Ite
     (item.id, item.version.0)
 });
 
-/// Decoder for `ObjectPrefix`.
+/// Decoder for [`ObjectPrefix`](../../../entity/object/struct.ObjectPrefix.html).
 #[derive(Debug, Default)]
 pub struct ObjectPrefixDecoder {
     inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, StringDecoder>>>,
@@ -126,7 +126,7 @@ impl_message_decode!(ObjectPrefixDecoder, ObjectPrefix, |t: _| {
     Ok(ObjectPrefix(t))
 });
 
-/// Encoder for `ObjectPrefix`.
+/// Encoder for [`ObjectPrefix`](../../../entity/object/struct.ObjectPrefix.html).
 #[derive(Debug, Default)]
 pub struct ObjectPrefixEncoder {
     inner: MessageEncoder<FieldEncoder<F1, StringEncoder>>,
@@ -136,7 +136,7 @@ impl_sized_message_encode!(ObjectPrefixEncoder, ObjectPrefix, |item: Self::Item|
     item.0
 });
 
-/// Decoder for `DeleteObjectsByPrefixSummary`.
+/// Decoder for [`DeleteObjectsByPrefixSummary`](../../../entity/object/struct.DeleteObjectsByPrefixSummary.html).
 #[derive(Debug, Default)]
 pub struct DeleteObjectsByPrefixSummaryDecoder {
     inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, Uint64Decoder>>>,
@@ -148,7 +148,7 @@ impl_message_decode!(
     |total: _| { Ok(DeleteObjectsByPrefixSummary { total }) }
 );
 
-/// Encoder for `DeleteObjectsByPrefixSummary`.
+/// Encoder for [`DeleteObjectsByPrefixSummary`](../../../entity/object/struct.DeleteObjectsByPrefixSummary.html).
 #[derive(Debug, Default)]
 pub struct DeleteObjectsByPrefixSummaryEncoder {
     inner: MessageEncoder<FieldEncoder<F1, Uint64Encoder>>,
@@ -160,7 +160,7 @@ impl_sized_message_encode!(
     |item: Self::Item| { item.total }
 );
 
-/// Decoder for `Metadata`.
+/// Decoder for [`Metadata`](../../../entity/object/struct.Metadata.html).
 #[derive(Debug, Default)]
 pub struct MetadataDecoder {
     inner: MessageDecoder<
@@ -178,7 +178,7 @@ impl_message_decode!(MetadataDecoder, Metadata, |t: (_, _)| {
     })
 });
 
-/// Encoder for `Metadata`.
+/// Encoder for [`Metadata`](../../../entity/object/struct.Metadata.html).
 #[derive(Debug, Default)]
 pub struct MetadataEncoder {
     inner: MessageEncoder<
@@ -193,7 +193,7 @@ impl_sized_message_encode!(MetadataEncoder, Metadata, |item: Self::Item| {
     (item.version.0, item.data)
 });
 
-/// Decoder for `FragmentsSummary`.
+/// Decoder for [`FragmentsSummary`](../../../entity/object/struct.FragmentsSummary.html).
 #[derive(Debug, Default)]
 pub struct FragmentsSummaryDecoder {
     inner: MessageDecoder<
@@ -213,7 +213,7 @@ impl_message_decode!(FragmentsSummaryDecoder, FragmentsSummary, |t: (_, _, _)| {
     })
 });
 
-/// Encoder for `FragmentsSummary`.
+/// Encoder for [`FragmentsSummary`](../../../entity/object/struct.FragmentsSummary.html).
 #[derive(Debug, Default)]
 pub struct FragmentsSummaryEncoder {
     inner: MessageEncoder<

--- a/src/protobuf/entity/server.rs
+++ b/src/protobuf/entity/server.rs
@@ -1,4 +1,6 @@
-//! Decoders and encoders for [libfrugalos.entity.server].
+//! Decoders and encoders for [`libfrugalos::entity::server`](../../entity/server/index.html).
+//!
+//! `package libfrugalos.protobuf.entity.server`.
 
 use protobuf_codec::field::num::{F1, F2, F3, F4};
 use protobuf_codec::field::{FieldDecoder, FieldEncoder, Fields, MaybeDefault};

--- a/src/protobuf/entity/server.rs
+++ b/src/protobuf/entity/server.rs
@@ -1,0 +1,93 @@
+//! Decoders and encoders for [libfrugalos.entity.server].
+
+use protobuf_codec::field::num::{F1, F2, F3, F4};
+use protobuf_codec::field::{FieldDecoder, FieldEncoder, Fields, MaybeDefault};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{StringDecoder, StringEncoder, Uint32Decoder, Uint32Encoder};
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use entity::server::{Server, ServerId, ServerSummary};
+
+/// Decoder for a host name.
+type HostDecoder = StringDecoder;
+
+/// Encoder for a host name.
+type HostEncoder = StringEncoder;
+
+/// Decoder for a port number.
+type PortDecoder = Uint32Decoder;
+
+/// Encoder for a port number.
+type PortEncoder = Uint32Encoder;
+
+/// Decoder for `ServerId`.
+pub type ServerIdDecoder = StringDecoder;
+
+/// Encoder for `ServerId`.
+pub type ServerIdEncoder = StringEncoder;
+
+/// Decoder for `SequenceNumber`.
+type SequenceNumberDecoder = Uint32Decoder;
+
+/// Encoder for `SequenceNumber`.
+type SequenceNumberEncoder = Uint32Encoder;
+
+/// Decoder for `ServerSummary`.
+#[derive(Debug, Default)]
+pub struct ServerSummaryDecoder {
+    inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, ServerIdDecoder>>>,
+}
+
+impl_message_decode!(ServerSummaryDecoder, ServerSummary, |t: _| {
+    Ok(ServerSummary { id: t })
+});
+
+/// Encoder for `ServerSummary`.
+#[derive(Debug, Default)]
+pub struct ServerSummaryEncoder {
+    inner: MessageEncoder<FieldEncoder<F1, ServerIdEncoder>>,
+}
+
+impl_sized_message_encode!(ServerSummaryEncoder, ServerSummary, |item: Self::Item| {
+    item.id
+});
+
+/// Decoder for `Server`.
+#[derive(Debug, Default)]
+pub struct ServerDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, ServerIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, SequenceNumberDecoder>>,
+            MaybeDefault<FieldDecoder<F3, HostDecoder>>,
+            MaybeDefault<FieldDecoder<F4, PortDecoder>>,
+        )>,
+    >,
+}
+
+impl_message_decode!(ServerDecoder, Server, |t: (ServerId, u32, String, u32)| {
+    Ok(Server {
+        id: t.0.clone(),
+        seqno: t.1,
+        host: track_any_err!(IpAddr::from_str(&t.2))?,
+        port: t.3 as u16,
+    })
+});
+
+/// Encoder for `Server`.
+#[derive(Debug, Default)]
+pub struct ServerEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, ServerIdEncoder>,
+            FieldEncoder<F2, SequenceNumberEncoder>,
+            FieldEncoder<F3, HostEncoder>,
+            FieldEncoder<F4, PortEncoder>,
+        )>,
+    >,
+}
+
+impl_sized_message_encode!(ServerEncoder, Server, |item: Self::Item| {
+    (item.id, item.seqno, item.host.to_string(), item.port as u32)
+});

--- a/src/protobuf/error.rs
+++ b/src/protobuf/error.rs
@@ -1,3 +1,5 @@
+//! Decoders and encoders for [`libfrugalos::Error`](../../struct.Error.html).
+//!
 //! `package libfrugalos.protobuf.error;`
 use bytecodec::combinator::PreEncode;
 use bytecodec::{ByteCount, Decode, Encode, Eos, Result};
@@ -21,7 +23,7 @@ use entity::object::ObjectVersion;
 use protobuf::entity::object::{ObjectVersionDecoder, ObjectVersionEncoder};
 use ErrorKind;
 
-/// Decoder for [Error].
+/// Decoder for [Error](../../struct.Error.html).
 #[derive(Debug, Default)]
 pub struct ErrorDecoder {
     inner: MessageDecoder<
@@ -70,7 +72,7 @@ impl Decode for ErrorDecoder {
 }
 impl MessageDecode for ErrorDecoder {}
 
-/// Encoder for [Error].
+/// Encoder for [Error](../../struct.Error.html).
 #[derive(Debug, Default)]
 pub struct ErrorEncoder {
     inner: MessageEncoder<
@@ -117,7 +119,7 @@ impl Encode for ErrorEncoder {
 }
 impl MessageEncode for ErrorEncoder {}
 
-/// Decoder for [error.ErrorKind].
+/// Decoder for [ErrorKind](../../enum.ErrorKind.html).
 #[derive(Debug, Default)]
 pub struct ErrorKindDecoder {
     inner: MessageDecoder<
@@ -148,22 +150,22 @@ impl_message_decode!(ErrorKindDecoder, ErrorKind, |t: _| {
     })
 });
 
-/// Encoder for [error.ErrorKind].
+/// Encoder for [ErrorKind](../../enum.ErrorKind.html).
 #[derive(Debug, Default)]
 pub struct ErrorKindEncoder {
     inner: MessageEncoder<
         Oneof<(
-            // [ErrorKind::InvalidInput]
+            // InvalidInput
             MessageFieldEncoder<F1, EmptyMessageEncoder>,
-            // [ErrorKind::Unavailable]
+            // Unavailable
             MessageFieldEncoder<F2, EmptyMessageEncoder>,
-            // [ErrorKind::Timeout]
+            // Timeout
             MessageFieldEncoder<F3, EmptyMessageEncoder>,
-            // [ErrorKind::NotLeader]
+            // NotLeader
             MessageFieldEncoder<F4, EmptyMessageEncoder>,
-            // [ErrorKind::Unexpected]
+            // Unexpected
             MessageFieldEncoder<F5, ErrorKindUnexpectedEncoder>,
-            // [ErrorKind::Other]
+            // Other
             MessageFieldEncoder<F6, EmptyMessageEncoder>,
         )>,
     >,
@@ -177,7 +179,7 @@ impl_sized_message_encode!(ErrorKindEncoder, ErrorKind, |item: Self::Item| match
     ErrorKind::Other => Branch6::F(()),
 });
 
-/// Decoder for [ErrorKind::Unexpected].
+/// Decoder for [ErrorKind::Unexpected](../../enum.ErrorKind.html#variant.Unexpected).
 #[derive(Debug, Default)]
 pub struct ErrorKindUnexpectedDecoder {
     inner: MessageDecoder<Optional<FieldDecoder<F1, ObjectVersionDecoder>>>,
@@ -188,7 +190,7 @@ impl_message_decode!(
     |t: Option<u64>| Ok(t.map(ObjectVersion))
 );
 
-/// Encoder for [ErrorKind::Unexpected].
+/// Encoder for [ErrorKind::Unexpected](../../enum.ErrorKind.html#variant.Unexpected).
 #[derive(Debug, Default)]
 pub struct ErrorKindUnexpectedEncoder {
     inner: MessageEncoder<Optional<FieldEncoder<F1, ObjectVersionEncoder>>>,

--- a/src/protobuf/error.rs
+++ b/src/protobuf/error.rs
@@ -1,0 +1,200 @@
+//! `package libfrugalos.protobuf.error;`
+use bytecodec::combinator::PreEncode;
+use bytecodec::{ByteCount, Decode, Encode, Eos, Result};
+use protobuf_codec::field::branch::Branch6;
+use protobuf_codec::field::num::{F1, F2, F3, F4, F5, F6};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, Fields, MaybeDefault, MessageFieldDecoder, MessageFieldEncoder,
+    Oneof, Optional, Repeated,
+};
+use protobuf_codec::message::{MessageDecode, MessageDecoder, MessageEncode, MessageEncoder};
+use protobuf_codec::scalar::{StringDecoder, StringEncoder};
+use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMessageEncoder};
+use protobuf_codec::wellknown::protobuf_codec::protobuf::trackable::{
+    LocationDecoder, LocationEncoder,
+};
+use std::error::Error;
+use trackable::error::{ErrorKindExt, TrackableError};
+use trackable::{Location, Trackable};
+
+use entity::object::ObjectVersion;
+use protobuf::entity::object::{ObjectVersionDecoder, ObjectVersionEncoder};
+use ErrorKind;
+
+/// Decoder for [Error].
+#[derive(Debug, Default)]
+pub struct ErrorDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MessageFieldDecoder<F1, ErrorKindDecoder>,
+            MaybeDefault<FieldDecoder<F2, StringDecoder>>,
+            Repeated<MessageFieldDecoder<F3, LocationDecoder>, Vec<Location>>,
+        )>,
+    >,
+}
+impl ErrorDecoder {
+    /// Makes a new `ErrorDecoder` instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+impl Decode for ErrorDecoder {
+    type Item = TrackableError<ErrorKind>;
+
+    fn decode(&mut self, buf: &[u8], eos: Eos) -> Result<usize> {
+        track!(self.inner.decode(buf, eos))
+    }
+
+    fn finish_decoding(&mut self) -> Result<Self::Item> {
+        let (kind, cause, locations) = track!(self.inner.finish_decoding())?;
+        let mut e = if cause.is_empty() {
+            kind.error()
+        } else {
+            kind.cause(cause)
+        };
+        if let Some(h) = e.history_mut() {
+            for l in locations {
+                h.add(l);
+            }
+        }
+        Ok(e)
+    }
+
+    fn requiring_bytes(&self) -> ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl MessageDecode for ErrorDecoder {}
+
+/// Encoder for [Error].
+#[derive(Debug, Default)]
+pub struct ErrorEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            MessageFieldEncoder<F1, PreEncode<ErrorKindEncoder>>,
+            MaybeDefault<FieldEncoder<F2, StringEncoder>>,
+            Repeated<MessageFieldEncoder<F3, LocationEncoder>, Vec<Location>>,
+        )>,
+    >,
+}
+impl ErrorEncoder {
+    /// Makes a new `ErrorEncoder` instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+impl Encode for ErrorEncoder {
+    type Item = TrackableError<ErrorKind>;
+
+    fn encode(&mut self, buf: &mut [u8], eos: Eos) -> Result<usize> {
+        track!(self.inner.encode(buf, eos))
+    }
+
+    fn start_encoding(&mut self, item: Self::Item) -> Result<()> {
+        let item = (
+            *item.kind(),
+            item.source()
+                .map(|e| e.to_string())
+                .unwrap_or_else(String::new),
+            item.history()
+                .map(|h| h.events().to_owned())
+                .unwrap_or_else(Vec::new),
+        );
+        track!(self.inner.start_encoding(item))
+    }
+
+    fn requiring_bytes(&self) -> ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl MessageEncode for ErrorEncoder {}
+
+/// Decoder for [error.ErrorKind].
+#[derive(Debug, Default)]
+pub struct ErrorKindDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            // [ErrorKind::InvalidInput]
+            MessageFieldDecoder<F1, EmptyMessageDecoder>,
+            // [ErrorKind::Unavailable]
+            MessageFieldDecoder<F2, EmptyMessageDecoder>,
+            // [ErrorKind::Timeout]
+            MessageFieldDecoder<F3, EmptyMessageDecoder>,
+            // [ErrorKind::NotLeader]
+            MessageFieldDecoder<F4, EmptyMessageDecoder>,
+            // [ErrorKind::Unexpected]
+            MessageFieldDecoder<F5, ErrorKindUnexpectedDecoder>,
+            // [ErrorKind::Other]
+            MessageFieldDecoder<F6, EmptyMessageDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(ErrorKindDecoder, ErrorKind, |t: _| {
+    Ok(match t {
+        Branch6::A(_) => ErrorKind::InvalidInput,
+        Branch6::B(_) => ErrorKind::Unavailable,
+        Branch6::C(_) => ErrorKind::Timeout,
+        Branch6::D(_) => ErrorKind::NotLeader,
+        Branch6::E(version) => ErrorKind::Unexpected(version),
+        Branch6::F(_) => ErrorKind::Other,
+    })
+});
+
+/// Encoder for [error.ErrorKind].
+#[derive(Debug, Default)]
+pub struct ErrorKindEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            // [ErrorKind::InvalidInput]
+            MessageFieldEncoder<F1, EmptyMessageEncoder>,
+            // [ErrorKind::Unavailable]
+            MessageFieldEncoder<F2, EmptyMessageEncoder>,
+            // [ErrorKind::Timeout]
+            MessageFieldEncoder<F3, EmptyMessageEncoder>,
+            // [ErrorKind::NotLeader]
+            MessageFieldEncoder<F4, EmptyMessageEncoder>,
+            // [ErrorKind::Unexpected]
+            MessageFieldEncoder<F5, ErrorKindUnexpectedEncoder>,
+            // [ErrorKind::Other]
+            MessageFieldEncoder<F6, EmptyMessageEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(ErrorKindEncoder, ErrorKind, |item: Self::Item| match item {
+    ErrorKind::InvalidInput => Branch6::A(()),
+    ErrorKind::Unavailable => Branch6::B(()),
+    ErrorKind::Timeout => Branch6::C(()),
+    ErrorKind::NotLeader => Branch6::D(()),
+    ErrorKind::Unexpected(version) => Branch6::E(version),
+    ErrorKind::Other => Branch6::F(()),
+});
+
+/// Decoder for [ErrorKind::Unexpected].
+#[derive(Debug, Default)]
+pub struct ErrorKindUnexpectedDecoder {
+    inner: MessageDecoder<Optional<FieldDecoder<F1, ObjectVersionDecoder>>>,
+}
+impl_message_decode!(
+    ErrorKindUnexpectedDecoder,
+    Option<ObjectVersion>,
+    |t: Option<u64>| Ok(t.map(ObjectVersion))
+);
+
+/// Encoder for [ErrorKind::Unexpected].
+#[derive(Debug, Default)]
+pub struct ErrorKindUnexpectedEncoder {
+    inner: MessageEncoder<Optional<FieldEncoder<F1, ObjectVersionEncoder>>>,
+}
+impl_sized_message_encode!(
+    ErrorKindUnexpectedEncoder,
+    Option<ObjectVersion>,
+    |item: Self::Item| item.map(|v| v.0)
+);

--- a/src/protobuf/expect.rs
+++ b/src/protobuf/expect.rs
@@ -1,4 +1,6 @@
-//! `package libfrugalos.protobuf.expect;`
+//! Decoders and encoders for [`libfrugalos::expect`](../../expect/index.html).
+//!
+//! `package libfrugalos.protobuf.expect`.
 
 use bytecodec::combinator::PreEncode;
 use protobuf_codec::field::branch::Branch4;
@@ -11,14 +13,18 @@ use entity::object::ObjectVersion;
 use expect::Expect;
 use protobuf::entity::object::{ObjectVersionsDecoder, ObjectVersionsEncoder};
 
-/// Decoder for `Expect`.
+/// Decoder for [`Expect`](../../expect/enum.Expect.html).
 #[derive(Debug, Default)]
 pub struct ExpectDecoder {
     inner: MessageDecoder<
         Oneof<(
+            // Any
             MessageFieldDecoder<F1, EmptyMessageDecoder>,
+            // None
             MessageFieldDecoder<F2, EmptyMessageDecoder>,
+            // IfMatch
             MessageFieldDecoder<F3, ObjectVersionsDecoder>,
+            // IfNoneMatch
             MessageFieldDecoder<F4, ObjectVersionsDecoder>,
         )>,
     >,
@@ -39,14 +45,18 @@ impl_message_decode!(ExpectDecoder, Expect, |t: Branch4<
     })
 });
 
-/// Encoder for `Expect`.
+/// Encoder for [`Expect`](../../expect/enum.Expect.html).
 #[derive(Debug, Default)]
 pub struct ExpectEncoder {
     inner: MessageEncoder<
         Oneof<(
+            // Any
             MessageFieldEncoder<F1, EmptyMessageEncoder>,
+            // None
             MessageFieldEncoder<F2, EmptyMessageEncoder>,
+            // IfMatch
             MessageFieldEncoder<F3, PreEncode<ObjectVersionsEncoder>>,
+            // IfNoneMatch
             MessageFieldEncoder<F4, PreEncode<ObjectVersionsEncoder>>,
         )>,
     >,

--- a/src/protobuf/expect.rs
+++ b/src/protobuf/expect.rs
@@ -1,0 +1,61 @@
+//! `package libfrugalos.protobuf.expect;`
+
+use bytecodec::combinator::PreEncode;
+use protobuf_codec::field::branch::Branch4;
+use protobuf_codec::field::num::{F1, F2, F3, F4};
+use protobuf_codec::field::{MessageFieldDecoder, MessageFieldEncoder, Oneof};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMessageEncoder};
+
+use entity::object::ObjectVersion;
+use expect::Expect;
+use protobuf::entity::object::{ObjectVersionsDecoder, ObjectVersionsEncoder};
+
+/// Decoder for `Expect`.
+#[derive(Debug, Default)]
+pub struct ExpectDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            MessageFieldDecoder<F1, EmptyMessageDecoder>,
+            MessageFieldDecoder<F2, EmptyMessageDecoder>,
+            MessageFieldDecoder<F3, ObjectVersionsDecoder>,
+            MessageFieldDecoder<F4, ObjectVersionsDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(ExpectDecoder, Expect, |t: Branch4<
+    _,
+    _,
+    Vec<u64>,
+    Vec<u64>,
+>| {
+    Ok(match t {
+        Branch4::A(_) => Expect::Any,
+        Branch4::B(_) => Expect::None,
+        Branch4::C(versions) => Expect::IfMatch(versions.into_iter().map(ObjectVersion).collect()),
+        Branch4::D(versions) => {
+            Expect::IfNoneMatch(versions.into_iter().map(ObjectVersion).collect())
+        }
+    })
+});
+
+/// Encoder for `Expect`.
+#[derive(Debug, Default)]
+pub struct ExpectEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            MessageFieldEncoder<F1, EmptyMessageEncoder>,
+            MessageFieldEncoder<F2, EmptyMessageEncoder>,
+            MessageFieldEncoder<F3, PreEncode<ObjectVersionsEncoder>>,
+            MessageFieldEncoder<F4, PreEncode<ObjectVersionsEncoder>>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(ExpectEncoder, Expect, |item: Self::Item| {
+    match item {
+        Expect::Any => Branch4::A(()),
+        Expect::None => Branch4::B(()),
+        Expect::IfMatch(versions) => Branch4::C(versions.into_iter().map(|v| v.0).collect()),
+        Expect::IfNoneMatch(versions) => Branch4::D(versions.into_iter().map(|v| v.0).collect()),
+    }
+});

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -20,12 +20,14 @@ pub mod deadline;
 pub mod entity;
 pub mod error;
 pub mod expect;
+pub mod multiplicity;
 pub mod net;
 pub mod repair;
 pub mod schema;
 
 /// Decoder for `u64`.
 pub type Uint64NewTypeDecoder = MessageDecoder<FieldDecoder<F1, Uint64Decoder>>;
+
 /// Encoder for `u64`.
 pub type Uint64NewTypeEncoder = MessageEncoder<FieldEncoder<F1, Uint64Encoder>>;
 

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -29,8 +29,16 @@ pub type Uint64NewTypeDecoder = MessageDecoder<FieldDecoder<F1, Uint64Decoder>>;
 /// Encoder for `u64`.
 pub type Uint64NewTypeEncoder = MessageEncoder<FieldEncoder<F1, Uint64Encoder>>;
 
+/// Decoder for [`Vec`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html).
+///
+/// This decoder decodes the following message:
+///
+/// ```protobuf
+/// message Vec {
+///     repeated T values = 1;
+/// }
+/// ```
 // TODO Vec を汎用化する
-/// Decoder for `Vec`.
 #[derive(Debug, Default)]
 pub struct VecDecoder<D>
 where
@@ -59,7 +67,15 @@ impl<D: MessageDecode> ::bytecodec::Decode for VecDecoder<D> {
 }
 impl<D: MessageDecode> ::protobuf_codec::message::MessageDecode for VecDecoder<D> {}
 
-/// Encoder for `Vec`.
+/// Encoder for [`Vec`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html).
+///
+/// This encoder encodes the following message:
+///
+/// ```protobuf
+/// message Vec {
+///     repeated T values = 1;
+/// }
+/// ```
 #[derive(Debug, Default)]
 pub struct VecEncoder<E>
 where
@@ -88,7 +104,15 @@ impl<E: MessageEncode> ::bytecodec::Encode for VecEncoder<E> {
 }
 impl<E: MessageEncode> ::protobuf_codec::message::MessageEncode for VecEncoder<E> {}
 
-/// Decoder for `Option`.
+/// Decoder for [`Option`](https://doc.rust-lang.org/stable/std/option/enum.Option.html).
+///
+/// This decoder decodes the following message:
+///
+/// ```protobuf
+/// message Option {
+///     T some = 1;
+/// }
+/// ```
 #[derive(Debug, Default)]
 pub struct OptionDecoder<D>
 where
@@ -117,7 +141,15 @@ impl<D: MessageDecode> ::bytecodec::Decode for OptionDecoder<D> {
 }
 impl<D: MessageDecode> ::protobuf_codec::message::MessageDecode for OptionDecoder<D> {}
 
-/// Encoder for `Option`.
+/// Encoder for [`Option`](https://doc.rust-lang.org/stable/std/option/enum.Option.html).
+///
+/// This encoder encodes the following message:
+///
+/// ```protobuf
+/// message Option {
+///     T some = 1;
+/// }
+/// ```
 #[derive(Debug, Default)]
 pub struct OptionEncoder<E>
 where
@@ -151,7 +183,26 @@ impl<E: MessageEncode + SizedEncode> ::bytecodec::SizedEncode for OptionEncoder<
     }
 }
 
-/// Decoder for `Result`.
+/// Decoder for [`Result`](https://doc.rust-lang.org/stable/std/result/enum.Result.html).
+///
+/// This decoder decodes the following message:
+///
+/// ```protobuf
+/// import "libfrugalos/protobuf/error.proto";
+///
+/// message Result {
+///     T ok = 1;
+///     Error err = 2;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use libfrugalos::protobuf::ResultDecoder;
+/// use libfrugalos::protobuf::entity::object::ObjectVersionDecoder;
+/// type PutObjectResponseDecoder = ResultDecoder<ObjectVersionDecoder>;
+/// ```
 #[derive(Debug, Default)]
 pub struct ResultDecoder<D>
 where
@@ -189,7 +240,26 @@ impl<D: MessageDecode> ::bytecodec::Decode for ResultDecoder<D> {
 }
 impl<D: MessageDecode> ::protobuf_codec::message::MessageDecode for ResultDecoder<D> {}
 
-/// Encoder for `Result`.
+/// Encoder for [`Result`](https://doc.rust-lang.org/stable/std/result/enum.Result.html).
+///
+/// This encoder encodes the following message:
+///
+/// ```protobuf
+/// import "libfrugalos/protobuf/error.proto";
+///
+/// message Result {
+///     T ok = 1;
+///     Error err = 2;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use libfrugalos::protobuf::ResultEncoder;
+/// use libfrugalos::protobuf::entity::object::ObjectVersionEncoder;
+/// type PutObjectResponseEncoder = ResultEncoder<ObjectVersionEncoder>;
+/// ```
 #[derive(Debug, Default)]
 pub struct ResultEncoder<E>
 where

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -5,11 +5,8 @@ use bytecodec::combinator::PreEncode;
 use bytecodec::SizedEncode;
 use protobuf_codec::field::branch::Branch2;
 use protobuf_codec::field::num::{F1, F2};
-use protobuf_codec::field::{
-    FieldDecoder, FieldEncoder, MessageFieldDecoder, MessageFieldEncoder, Oneof, Optional, Repeated,
-};
+use protobuf_codec::field::{MessageFieldDecoder, MessageFieldEncoder, Oneof, Optional, Repeated};
 use protobuf_codec::message::{MessageDecode, MessageDecoder, MessageEncode, MessageEncoder};
-use protobuf_codec::scalar::{Uint64Decoder, Uint64Encoder};
 use trackable::error::ErrorKindExt;
 
 use protobuf::error::{ErrorDecoder, ErrorEncoder};
@@ -24,12 +21,6 @@ pub mod multiplicity;
 pub mod net;
 pub mod repair;
 pub mod schema;
-
-/// Decoder for `u64`.
-pub type Uint64NewTypeDecoder = MessageDecoder<FieldDecoder<F1, Uint64Decoder>>;
-
-/// Encoder for `u64`.
-pub type Uint64NewTypeEncoder = MessageEncoder<FieldEncoder<F1, Uint64Encoder>>;
 
 /// Decoder for [`Vec`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html).
 ///

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -216,7 +216,7 @@ impl<D: MessageDecode> ::bytecodec::Decode for ResultDecoder<D> {
 
     fn finish_decoding(&mut self) -> ::bytecodec::Result<Self::Item> {
         match track!(self.inner.finish_decoding())? {
-            Branch2::A(value) => Ok(Ok(value)),
+            Branch2::A(value) => Ok(track!(Ok(value))),
             Branch2::B(e) => Ok(track!(Err(e.into()))),
         }
     }

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -1,0 +1,236 @@
+//! Encoders and decoders of Protocol Buffers.
+#![allow(clippy::type_complexity)]
+
+use bytecodec::combinator::PreEncode;
+use bytecodec::SizedEncode;
+use protobuf_codec::field::branch::Branch2;
+use protobuf_codec::field::num::{F1, F2};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, MessageFieldDecoder, MessageFieldEncoder, Oneof, Optional, Repeated,
+};
+use protobuf_codec::message::{MessageDecode, MessageDecoder, MessageEncode, MessageEncoder};
+use protobuf_codec::scalar::{Uint64Decoder, Uint64Encoder};
+use trackable::error::ErrorKindExt;
+
+use protobuf::error::{ErrorDecoder, ErrorEncoder};
+use {ErrorKind, Result};
+
+pub mod consistency;
+pub mod deadline;
+pub mod entity;
+pub mod error;
+pub mod expect;
+pub mod net;
+pub mod repair;
+pub mod schema;
+
+/// Decoder for `u64`.
+pub type Uint64NewTypeDecoder = MessageDecoder<FieldDecoder<F1, Uint64Decoder>>;
+/// Encoder for `u64`.
+pub type Uint64NewTypeEncoder = MessageEncoder<FieldEncoder<F1, Uint64Encoder>>;
+
+// TODO Vec を汎用化する
+/// Decoder for `Vec`.
+#[derive(Debug, Default)]
+pub struct VecDecoder<D>
+where
+    D: MessageDecode,
+{
+    inner: MessageDecoder<Repeated<MessageFieldDecoder<F1, D>, Vec<D::Item>>>,
+}
+impl<D: MessageDecode> ::bytecodec::Decode for VecDecoder<D> {
+    type Item = Vec<D::Item>;
+
+    fn decode(&mut self, buf: &[u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.decode(buf, eos))
+    }
+
+    fn finish_decoding(&mut self) -> ::bytecodec::Result<Self::Item> {
+        track!(self.inner.finish_decoding())
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl<D: MessageDecode> ::protobuf_codec::message::MessageDecode for VecDecoder<D> {}
+
+/// Encoder for `Vec`.
+#[derive(Debug, Default)]
+pub struct VecEncoder<E>
+where
+    E: MessageEncode,
+{
+    inner: MessageEncoder<Repeated<MessageFieldEncoder<F1, PreEncode<E>>, Vec<E::Item>>>,
+}
+impl<E: MessageEncode> ::bytecodec::Encode for VecEncoder<E> {
+    type Item = Vec<E::Item>;
+
+    fn encode(&mut self, buf: &mut [u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.encode(buf, eos))
+    }
+
+    fn start_encoding(&mut self, item: Self::Item) -> ::bytecodec::Result<()> {
+        track!(self.inner.start_encoding(item))
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl<E: MessageEncode> ::protobuf_codec::message::MessageEncode for VecEncoder<E> {}
+
+/// Decoder for `Option`.
+#[derive(Debug, Default)]
+pub struct OptionDecoder<D>
+where
+    D: MessageDecode,
+{
+    inner: MessageDecoder<Optional<MessageFieldDecoder<F1, D>>>,
+}
+impl<D: MessageDecode> ::bytecodec::Decode for OptionDecoder<D> {
+    type Item = Option<D::Item>;
+
+    fn decode(&mut self, buf: &[u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.decode(buf, eos))
+    }
+
+    fn finish_decoding(&mut self) -> ::bytecodec::Result<Self::Item> {
+        track!(self.inner.finish_decoding())
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl<D: MessageDecode> ::protobuf_codec::message::MessageDecode for OptionDecoder<D> {}
+
+/// Encoder for `Option`.
+#[derive(Debug, Default)]
+pub struct OptionEncoder<E>
+where
+    E: MessageEncode,
+{
+    inner: MessageEncoder<Optional<MessageFieldEncoder<F1, PreEncode<E>>>>,
+}
+impl<E: MessageEncode> ::bytecodec::Encode for OptionEncoder<E> {
+    type Item = Option<E::Item>;
+
+    fn encode(&mut self, buf: &mut [u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.encode(buf, eos))
+    }
+
+    fn start_encoding(&mut self, item: Self::Item) -> ::bytecodec::Result<()> {
+        track!(self.inner.start_encoding(item))
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl<E: MessageEncode> ::protobuf_codec::message::MessageEncode for OptionEncoder<E> {}
+impl<E: MessageEncode + SizedEncode> ::bytecodec::SizedEncode for OptionEncoder<E> {
+    fn exact_requiring_bytes(&self) -> u64 {
+        self.inner.exact_requiring_bytes()
+    }
+}
+
+/// Decoder for `Result`.
+#[derive(Debug, Default)]
+pub struct ResultDecoder<D>
+where
+    D: MessageDecode,
+{
+    inner: MessageDecoder<
+        Oneof<(
+            MessageFieldDecoder<F1, D>,
+            MessageFieldDecoder<F2, ErrorDecoder>,
+        )>,
+    >,
+}
+impl<D: MessageDecode> ::bytecodec::Decode for ResultDecoder<D> {
+    type Item = Result<D::Item>;
+
+    fn decode(&mut self, buf: &[u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.decode(buf, eos))
+    }
+
+    fn finish_decoding(&mut self) -> ::bytecodec::Result<Self::Item> {
+        match track!(self.inner.finish_decoding())? {
+            Branch2::A(value) => Ok(Ok(value)),
+            // TODO InvalidInput 再検討
+            Branch2::B(e) => Ok(track!(Err(ErrorKind::InvalidInput.takes_over(e).into()))),
+        }
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl<D: MessageDecode> ::protobuf_codec::message::MessageDecode for ResultDecoder<D> {}
+
+/// Encoder for `Result`.
+#[derive(Debug, Default)]
+pub struct ResultEncoder<E>
+where
+    E: MessageEncode,
+{
+    inner: MessageEncoder<
+        Oneof<(
+            MessageFieldEncoder<F1, PreEncode<E>>,
+            MessageFieldEncoder<F2, PreEncode<ErrorEncoder>>,
+        )>,
+    >,
+}
+impl<E: MessageEncode> ::bytecodec::Encode for ResultEncoder<E> {
+    type Item = Result<E::Item>;
+
+    fn encode(&mut self, buf: &mut [u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.encode(buf, eos))
+    }
+
+    fn start_encoding(&mut self, item: Self::Item) -> ::bytecodec::Result<()> {
+        let item = match item {
+            Ok(x) => Branch2::A(x),
+            Err(e) => {
+                // TODO InvalidInput 再検討
+                Branch2::B(ErrorKind::InvalidInput.takes_over(e))
+            }
+        };
+        track!(self.inner.start_encoding(item))
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl<E: MessageEncode> ::protobuf_codec::message::MessageEncode for ResultEncoder<E> {}
+impl<E: MessageEncode + SizedEncode> ::bytecodec::SizedEncode for ResultEncoder<E> {
+    fn exact_requiring_bytes(&self) -> u64 {
+        self.inner.exact_requiring_bytes()
+    }
+}

--- a/src/protobuf/multiplicity.rs
+++ b/src/protobuf/multiplicity.rs
@@ -49,3 +49,27 @@ impl_sized_message_encode!(
         )
     }
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytecodec::io::{IoDecodeExt, IoEncodeExt};
+    use bytecodec::EncodeExt;
+    use trackable::result::TestResult;
+
+    #[test]
+    fn encode_works() -> TestResult {
+        let mut buf = Vec::new();
+        let config = MultiplicityConfig {
+            inner_retry_count: InnerRetryCount(1),
+            number_of_ensured_saves: NumberOfEnsuredSaves(3),
+        };
+        let mut decoder = MultiplicityConfigDecoder::default();
+        let mut encoder = track!(MultiplicityConfigEncoder::with_item(config.clone()))?;
+        track!(encoder.inner.encode_all(&mut buf))?;
+        assert_eq!(buf, [8, 1, 16, 3]);
+        let message = track!(decoder.decode_exact(&buf[..]))?;
+        assert_eq!(config, message);
+        Ok(())
+    }
+}

--- a/src/protobuf/multiplicity.rs
+++ b/src/protobuf/multiplicity.rs
@@ -1,0 +1,51 @@
+//! Decoders and encoders for [`libfrugalos::multiplicity`](../../multiplicity/index.html).
+//!
+//! `package libfrugalos.protobuf.multiplicity;`
+
+use protobuf_codec::field::num::{F1, F2};
+use protobuf_codec::field::{FieldDecoder, FieldEncoder, Fields, MaybeDefault};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{Uint64Decoder, Uint64Encoder};
+
+use multiplicity::{InnerRetryCount, MultiplicityConfig, NumberOfEnsuredSaves};
+
+/// Decoder for [`MultiplicityConfig`](../../multiplicity/struct.MultiplicityConfig.html).
+#[derive(Debug, Default)]
+pub struct MultiplicityConfigDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, Uint64Decoder>>,
+            MaybeDefault<FieldDecoder<F2, Uint64Decoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(MultiplicityConfigDecoder, MultiplicityConfig, |t: (
+    _,
+    _
+)| {
+    Ok(MultiplicityConfig {
+        inner_retry_count: InnerRetryCount(t.0 as usize),
+        number_of_ensured_saves: NumberOfEnsuredSaves(t.1 as usize),
+    })
+});
+
+/// Encoder for [`MultiplicityConfig`](../../multiplicity/struct.MultiplicityConfig.html).
+#[derive(Debug, Default)]
+pub struct MultiplicityConfigEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, Uint64Encoder>,
+            FieldEncoder<F2, Uint64Encoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    MultiplicityConfigEncoder,
+    MultiplicityConfig,
+    |item: Self::Item| {
+        (
+            item.inner_retry_count.0 as u64,
+            item.number_of_ensured_saves.0 as u64,
+        )
+    }
+);

--- a/src/protobuf/net.rs
+++ b/src/protobuf/net.rs
@@ -1,4 +1,6 @@
-//! `package libfrugalos.protobuf.net;`
+//! Decoders and encoders for [`std::net`](https://doc.rust-lang.org/stable/std/net/index.html).
+//!
+//! `package libfrugalos.protobuf.net`.
 
 use bytecodec::ErrorKind;
 use protobuf_codec::field::branch::Branch2;
@@ -9,7 +11,7 @@ use protobuf_codec::scalar::{StringDecoder, StringEncoder};
 use std::net::SocketAddr;
 use trackable::error::ErrorKindExt;
 
-/// Decoder for [std.net.SocketAddr].
+/// Decoder for [std::net::SocketAddr](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html).
 #[derive(Debug, Default)]
 pub struct SocketAddrDecoder {
     inner: MessageDecoder<
@@ -33,7 +35,7 @@ impl_message_decode!(SocketAddrDecoder, SocketAddr, |t: Branch2<
     }
 });
 
-/// Encoder for [std.net.SocketAddr].
+/// Encoder for [std::net::SocketAddr](https://doc.rust-lang.org/stable/std/net/enum.SocketAddr.html).
 #[derive(Debug, Default)]
 pub struct SocketAddrEncoder {
     inner: MessageEncoder<

--- a/src/protobuf/net.rs
+++ b/src/protobuf/net.rs
@@ -1,0 +1,51 @@
+//! `package libfrugalos.protobuf.net;`
+
+use bytecodec::ErrorKind;
+use protobuf_codec::field::branch::Branch2;
+use protobuf_codec::field::num::{F1, F2};
+use protobuf_codec::field::{FieldDecoder, FieldEncoder, Oneof};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{StringDecoder, StringEncoder};
+use std::net::SocketAddr;
+use trackable::error::ErrorKindExt;
+
+/// Decoder for [std.net.SocketAddr].
+#[derive(Debug, Default)]
+pub struct SocketAddrDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            FieldDecoder<F1, StringDecoder>,
+            FieldDecoder<F2, StringDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(SocketAddrDecoder, SocketAddr, |t: Branch2<
+    String,
+    String,
+>| {
+    match t {
+        Branch2::A(addr) => track!(addr
+            .parse()
+            .map_err(|e| ErrorKind::InvalidInput.cause(e).into())),
+        Branch2::B(addr) => track!(addr
+            .parse()
+            .map_err(|e| ErrorKind::InvalidInput.cause(e).into())),
+    }
+});
+
+/// Encoder for [std.net.SocketAddr].
+#[derive(Debug, Default)]
+pub struct SocketAddrEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            FieldEncoder<F1, StringEncoder>,
+            FieldEncoder<F2, StringEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(SocketAddrEncoder, SocketAddr, |item: Self::Item| {
+    match item {
+        SocketAddr::V4(addr) => Branch2::A(addr.to_string()),
+        SocketAddr::V6(addr) => Branch2::B(addr.to_string()),
+    }
+});

--- a/src/protobuf/repair.rs
+++ b/src/protobuf/repair.rs
@@ -1,0 +1,170 @@
+//! `package libfrugalos.protobuf.repair;`
+
+use bytecodec::ErrorKind;
+use protobuf_codec::field::branch::Branch2;
+use protobuf_codec::field::num::{F1, F2, F3};
+use protobuf_codec::field::{Fields, MessageFieldDecoder, MessageFieldEncoder, Oneof, Optional};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::wellknown::google::protobuf::{
+    DurationMessage, DurationMessageDecoder, DurationMessageEncoder, EmptyMessageDecoder,
+    EmptyMessageEncoder,
+};
+
+use protobuf::{Uint64NewTypeDecoder, Uint64NewTypeEncoder};
+use repair::{RepairConcurrencyLimit, RepairConfig, RepairIdleness, SegmentGcConcurrencyLimit};
+
+/// Decoder for `RepairConfig`.
+#[derive(Debug, Default)]
+pub struct RepairConfigDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            Optional<MessageFieldDecoder<F1, RepairConcurrencyLimitDecoder>>,
+            Optional<MessageFieldDecoder<F2, RepairIdlenessDecoder>>,
+            Optional<MessageFieldDecoder<F3, SegmentGcConcurrencyLimitDecoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(RepairConfigDecoder, RepairConfig, |t: (_, _, _,)| {
+    Ok(RepairConfig {
+        repair_concurrency_limit: t.0,
+        repair_idleness_threshold: t.1,
+        segment_gc_concurrency_limit: t.2,
+    })
+});
+
+/// Encoder for `RepairConfig`.
+#[derive(Debug, Default)]
+pub struct RepairConfigEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            Optional<MessageFieldEncoder<F1, RepairConcurrencyLimitEncoder>>,
+            Optional<MessageFieldEncoder<F2, RepairIdlenessEncoder>>,
+            Optional<MessageFieldEncoder<F3, SegmentGcConcurrencyLimitEncoder>>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(RepairConfigEncoder, RepairConfig, |item: Self::Item| {
+    (
+        item.repair_concurrency_limit,
+        item.repair_idleness_threshold,
+        item.segment_gc_concurrency_limit,
+    )
+});
+
+/// Decoder for `RepairIdleness`.
+#[derive(Debug, Default)]
+pub struct RepairIdlenessDecoder {
+    inner: MessageDecoder<
+        Oneof<(
+            // Threshold
+            MessageFieldDecoder<F1, DurationMessageDecoder>,
+            // Disabled
+            MessageFieldDecoder<F2, EmptyMessageDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(RepairIdlenessDecoder, RepairIdleness, |t: Branch2<
+    DurationMessage,
+    (),
+>| Ok(match t {
+    Branch2::A(threshold) => {
+        if let Some(duration) = threshold.to_duration() {
+            RepairIdleness::Threshold(duration)
+        } else {
+            track_panic!(
+                ErrorKind::InvalidInput,
+                "Invalid threshold: {:?}",
+                threshold
+            );
+        }
+    }
+    Branch2::B(_) => RepairIdleness::Disabled,
+}));
+
+/// Encoder for `RepairIdleness`.
+#[derive(Debug, Default)]
+pub struct RepairIdlenessEncoder {
+    inner: MessageEncoder<
+        Oneof<(
+            // Threshold
+            MessageFieldEncoder<F1, DurationMessageEncoder>,
+            // Disabled
+            MessageFieldEncoder<F2, EmptyMessageEncoder>,
+        )>,
+    >,
+}
+impl ::bytecodec::Encode for RepairIdlenessEncoder {
+    type Item = RepairIdleness;
+
+    fn encode(&mut self, buf: &mut [u8], eos: ::bytecodec::Eos) -> ::bytecodec::Result<usize> {
+        track!(self.inner.encode(buf, eos))
+    }
+
+    fn start_encoding(&mut self, item: Self::Item) -> ::bytecodec::Result<()> {
+        let item = match item {
+            RepairIdleness::Threshold(duration) => {
+                Branch2::A(track!(DurationMessage::from_duration(duration))?)
+            }
+            RepairIdleness::Disabled => Branch2::B(()),
+        };
+        track!(self.inner.start_encoding(item))
+    }
+
+    fn requiring_bytes(&self) -> ::bytecodec::ByteCount {
+        self.inner.requiring_bytes()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.is_idle()
+    }
+}
+impl ::protobuf_codec::message::MessageEncode for RepairIdlenessEncoder {}
+impl ::bytecodec::SizedEncode for RepairIdlenessEncoder {
+    fn exact_requiring_bytes(&self) -> u64 {
+        self.inner.exact_requiring_bytes()
+    }
+}
+
+/// Decoder for `RepairConcurrencyLimit`.
+#[derive(Debug, Default)]
+pub struct RepairConcurrencyLimitDecoder {
+    inner: Uint64NewTypeDecoder,
+}
+impl_message_decode!(
+    RepairConcurrencyLimitDecoder,
+    RepairConcurrencyLimit,
+    |t: _| Ok(RepairConcurrencyLimit(t))
+);
+
+/// Encoder for `RepairConcurrencyLimit`.
+#[derive(Debug, Default)]
+pub struct RepairConcurrencyLimitEncoder {
+    inner: Uint64NewTypeEncoder,
+}
+impl_sized_message_encode!(
+    RepairConcurrencyLimitEncoder,
+    RepairConcurrencyLimit,
+    |item: Self::Item| item.0
+);
+
+/// Decoder for `SegmentGcConcurrencyLimit`.
+#[derive(Debug, Default)]
+pub struct SegmentGcConcurrencyLimitDecoder {
+    inner: Uint64NewTypeDecoder,
+}
+impl_message_decode!(
+    SegmentGcConcurrencyLimitDecoder,
+    SegmentGcConcurrencyLimit,
+    |t: _| Ok(SegmentGcConcurrencyLimit(t))
+);
+
+/// Encoder for `SegmentGcConcurrencyLimit`.
+#[derive(Debug, Default)]
+pub struct SegmentGcConcurrencyLimitEncoder {
+    inner: Uint64NewTypeEncoder,
+}
+impl_sized_message_encode!(
+    SegmentGcConcurrencyLimitEncoder,
+    SegmentGcConcurrencyLimit,
+    |item: Self::Item| item.0
+);

--- a/src/protobuf/repair.rs
+++ b/src/protobuf/repair.rs
@@ -1,3 +1,5 @@
+//! Decoders and encoders for [`libfrugalos::repair`](../../repair/index.html).
+//!
 //! `package libfrugalos.protobuf.repair;`
 
 use bytecodec::ErrorKind;
@@ -13,7 +15,7 @@ use protobuf_codec::wellknown::google::protobuf::{
 use protobuf::{Uint64NewTypeDecoder, Uint64NewTypeEncoder};
 use repair::{RepairConcurrencyLimit, RepairConfig, RepairIdleness, SegmentGcConcurrencyLimit};
 
-/// Decoder for `RepairConfig`.
+/// Decoder for [`RepairConfig`](../../repair/struct.RepairConfig.html).
 #[derive(Debug, Default)]
 pub struct RepairConfigDecoder {
     inner: MessageDecoder<
@@ -32,7 +34,7 @@ impl_message_decode!(RepairConfigDecoder, RepairConfig, |t: (_, _, _,)| {
     })
 });
 
-/// Encoder for `RepairConfig`.
+/// Encoder for [`RepairConfig`](../../repair/struct.RepairConfig.html).
 #[derive(Debug, Default)]
 pub struct RepairConfigEncoder {
     inner: MessageEncoder<
@@ -51,7 +53,7 @@ impl_sized_message_encode!(RepairConfigEncoder, RepairConfig, |item: Self::Item|
     )
 });
 
-/// Decoder for `RepairIdleness`.
+/// Decoder for [`RepairIdleness`](../../repair/enum.RepairIdleness.html).
 #[derive(Debug, Default)]
 pub struct RepairIdlenessDecoder {
     inner: MessageDecoder<
@@ -81,7 +83,7 @@ impl_message_decode!(RepairIdlenessDecoder, RepairIdleness, |t: Branch2<
     Branch2::B(_) => RepairIdleness::Disabled,
 }));
 
-/// Encoder for `RepairIdleness`.
+/// Encoder for [`RepairIdleness`](../../repair/enum.RepairIdleness.html).
 #[derive(Debug, Default)]
 pub struct RepairIdlenessEncoder {
     inner: MessageEncoder<
@@ -125,7 +127,7 @@ impl ::bytecodec::SizedEncode for RepairIdlenessEncoder {
     }
 }
 
-/// Decoder for `RepairConcurrencyLimit`.
+/// Decoder for [`RepairConcurrencyLimit`](../../repair/struct.RepairConcurrencyLimit.html).
 #[derive(Debug, Default)]
 pub struct RepairConcurrencyLimitDecoder {
     inner: Uint64NewTypeDecoder,
@@ -136,7 +138,7 @@ impl_message_decode!(
     |t: _| Ok(RepairConcurrencyLimit(t))
 );
 
-/// Encoder for `RepairConcurrencyLimit`.
+/// Encoder for [`RepairConcurrencyLimit`](../../repair/struct.RepairConcurrencyLimit.html).
 #[derive(Debug, Default)]
 pub struct RepairConcurrencyLimitEncoder {
     inner: Uint64NewTypeEncoder,
@@ -147,7 +149,7 @@ impl_sized_message_encode!(
     |item: Self::Item| item.0
 );
 
-/// Decoder for `SegmentGcConcurrencyLimit`.
+/// Decoder for [`SegmentGcConcurrencyLimit`](../../repair/struct.SegmentGcConcurrencyLimit.html).
 #[derive(Debug, Default)]
 pub struct SegmentGcConcurrencyLimitDecoder {
     inner: Uint64NewTypeDecoder,
@@ -158,7 +160,7 @@ impl_message_decode!(
     |t: _| Ok(SegmentGcConcurrencyLimit(t))
 );
 
-/// Encoder for `SegmentGcConcurrencyLimit`.
+/// Encoder for [`SegmentGcConcurrencyLimit`](../../repair/struct.SegmentGcConcurrencyLimit.html).
 #[derive(Debug, Default)]
 pub struct SegmentGcConcurrencyLimitEncoder {
     inner: Uint64NewTypeEncoder,

--- a/src/protobuf/repair.rs
+++ b/src/protobuf/repair.rs
@@ -5,14 +5,16 @@
 use bytecodec::ErrorKind;
 use protobuf_codec::field::branch::Branch2;
 use protobuf_codec::field::num::{F1, F2, F3};
-use protobuf_codec::field::{Fields, MessageFieldDecoder, MessageFieldEncoder, Oneof, Optional};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, Fields, MessageFieldDecoder, MessageFieldEncoder, Oneof, Optional,
+};
 use protobuf_codec::message::{MessageDecoder, MessageEncoder};
 use protobuf_codec::wellknown::google::protobuf::{
     DurationMessage, DurationMessageDecoder, DurationMessageEncoder, EmptyMessageDecoder,
     EmptyMessageEncoder,
 };
 
-use protobuf::{Uint64NewTypeDecoder, Uint64NewTypeEncoder};
+use protobuf_codec::scalar::{Uint64Decoder, Uint64Encoder};
 use repair::{RepairConcurrencyLimit, RepairConfig, RepairIdleness, SegmentGcConcurrencyLimit};
 
 /// Decoder for [`RepairConfig`](../../repair/struct.RepairConfig.html).
@@ -20,17 +22,21 @@ use repair::{RepairConcurrencyLimit, RepairConfig, RepairIdleness, SegmentGcConc
 pub struct RepairConfigDecoder {
     inner: MessageDecoder<
         Fields<(
-            Optional<MessageFieldDecoder<F1, RepairConcurrencyLimitDecoder>>,
+            Optional<FieldDecoder<F1, Uint64Decoder>>,
             Optional<MessageFieldDecoder<F2, RepairIdlenessDecoder>>,
-            Optional<MessageFieldDecoder<F3, SegmentGcConcurrencyLimitDecoder>>,
+            Optional<FieldDecoder<F3, Uint64Decoder>>,
         )>,
     >,
 }
-impl_message_decode!(RepairConfigDecoder, RepairConfig, |t: (_, _, _,)| {
+impl_message_decode!(RepairConfigDecoder, RepairConfig, |t: (
+    Option<_>,
+    _,
+    Option<_>
+)| {
     Ok(RepairConfig {
-        repair_concurrency_limit: t.0,
+        repair_concurrency_limit: t.0.map(RepairConcurrencyLimit),
         repair_idleness_threshold: t.1,
-        segment_gc_concurrency_limit: t.2,
+        segment_gc_concurrency_limit: t.2.map(SegmentGcConcurrencyLimit),
     })
 });
 
@@ -39,17 +45,17 @@ impl_message_decode!(RepairConfigDecoder, RepairConfig, |t: (_, _, _,)| {
 pub struct RepairConfigEncoder {
     inner: MessageEncoder<
         Fields<(
-            Optional<MessageFieldEncoder<F1, RepairConcurrencyLimitEncoder>>,
+            Optional<FieldEncoder<F1, Uint64Encoder>>,
             Optional<MessageFieldEncoder<F2, RepairIdlenessEncoder>>,
-            Optional<MessageFieldEncoder<F3, SegmentGcConcurrencyLimitEncoder>>,
+            Optional<FieldEncoder<F3, Uint64Encoder>>,
         )>,
     >,
 }
 impl_sized_message_encode!(RepairConfigEncoder, RepairConfig, |item: Self::Item| {
     (
-        item.repair_concurrency_limit,
+        item.repair_concurrency_limit.map(|limit| limit.0),
         item.repair_idleness_threshold,
-        item.segment_gc_concurrency_limit,
+        item.segment_gc_concurrency_limit.map(|limit| limit.0),
     )
 });
 
@@ -126,47 +132,3 @@ impl ::bytecodec::SizedEncode for RepairIdlenessEncoder {
         self.inner.exact_requiring_bytes()
     }
 }
-
-/// Decoder for [`RepairConcurrencyLimit`](../../repair/struct.RepairConcurrencyLimit.html).
-#[derive(Debug, Default)]
-pub struct RepairConcurrencyLimitDecoder {
-    inner: Uint64NewTypeDecoder,
-}
-impl_message_decode!(
-    RepairConcurrencyLimitDecoder,
-    RepairConcurrencyLimit,
-    |t: _| Ok(RepairConcurrencyLimit(t))
-);
-
-/// Encoder for [`RepairConcurrencyLimit`](../../repair/struct.RepairConcurrencyLimit.html).
-#[derive(Debug, Default)]
-pub struct RepairConcurrencyLimitEncoder {
-    inner: Uint64NewTypeEncoder,
-}
-impl_sized_message_encode!(
-    RepairConcurrencyLimitEncoder,
-    RepairConcurrencyLimit,
-    |item: Self::Item| item.0
-);
-
-/// Decoder for [`SegmentGcConcurrencyLimit`](../../repair/struct.SegmentGcConcurrencyLimit.html).
-#[derive(Debug, Default)]
-pub struct SegmentGcConcurrencyLimitDecoder {
-    inner: Uint64NewTypeDecoder,
-}
-impl_message_decode!(
-    SegmentGcConcurrencyLimitDecoder,
-    SegmentGcConcurrencyLimit,
-    |t: _| Ok(SegmentGcConcurrencyLimit(t))
-);
-
-/// Encoder for [`SegmentGcConcurrencyLimit`](../../repair/struct.SegmentGcConcurrencyLimit.html).
-#[derive(Debug, Default)]
-pub struct SegmentGcConcurrencyLimitEncoder {
-    inner: Uint64NewTypeEncoder,
-}
-impl_sized_message_encode!(
-    SegmentGcConcurrencyLimitEncoder,
-    SegmentGcConcurrencyLimit,
-    |item: Self::Item| item.0
-);

--- a/src/protobuf/schema/config.rs
+++ b/src/protobuf/schema/config.rs
@@ -1,0 +1,295 @@
+//! test
+
+use bytecodec::combinator::PreEncode;
+use protobuf_codec::field::num::F1;
+use protobuf_codec::field::{MessageFieldDecoder, MessageFieldEncoder};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use std::net::SocketAddr;
+
+use entity::bucket::{Bucket, BucketSummary};
+use entity::device::{Device, DeviceSummary};
+use entity::server::{Server, ServerSummary};
+use protobuf::entity::bucket::{
+    BucketDecoder, BucketEncoder, BucketSummaryDecoder, BucketSummaryEncoder,
+};
+use protobuf::entity::device::{
+    DeviceDecoder, DeviceEncoder, DeviceSummaryDecoder, DeviceSummaryEncoder,
+};
+use protobuf::entity::server::{
+    ServerDecoder, ServerEncoder, ServerSummaryDecoder, ServerSummaryEncoder,
+};
+use protobuf::net::{SocketAddrDecoder, SocketAddrEncoder};
+use protobuf::{
+    OptionDecoder, OptionEncoder, ResultDecoder, ResultEncoder, VecDecoder, VecEncoder,
+};
+use Result;
+
+/// Decoder for `ListServers`.
+#[derive(Debug, Default)]
+pub struct ListServersResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<ServerSummaryDecoder>>>>,
+}
+impl_message_decode!(
+    ListServersResponseDecoder,
+    Result<Vec<ServerSummary>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for `ListServers`.
+#[derive(Debug, Default)]
+pub struct ListServersResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<ServerSummaryEncoder>>>>,
+    >,
+}
+impl_message_encode!(
+    ListServersResponseEncoder,
+    Result<Vec<ServerSummary>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `GetServer`.
+#[derive(Debug, Default)]
+pub struct GetServerResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<ServerDecoder>>>>,
+}
+impl_message_decode!(GetServerResponseDecoder, Result<Option<Server>>, |t: _| Ok(
+    t
+));
+
+/// Encoder for `GetServer`.
+#[derive(Debug, Default)]
+pub struct GetServerResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<ServerEncoder>>>>,
+}
+impl_sized_message_encode!(
+    GetServerResponseEncoder,
+    Result<Option<Server>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `PutServer`.
+#[derive(Debug, Default)]
+pub struct PutServerResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<ServerDecoder>>>,
+}
+impl_message_decode!(PutServerResponseDecoder, Result<Server>, |t: _| Ok(t));
+
+/// Encoder for `PutServer`.
+#[derive(Debug, Default)]
+pub struct PutServerResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<ServerEncoder>>>,
+}
+impl_sized_message_encode!(
+    PutServerResponseEncoder,
+    Result<Server>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `DeleteServer`.
+#[derive(Debug, Default)]
+pub struct DeleteServerResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<ServerDecoder>>>>,
+}
+impl_message_decode!(
+    DeleteServerResponseDecoder,
+    Result<Option<Server>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for `DeleteServer`.
+#[derive(Debug, Default)]
+pub struct DeleteServerResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<ServerEncoder>>>>,
+}
+impl_sized_message_encode!(
+    DeleteServerResponseEncoder,
+    Result<Option<Server>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `ListDevices`.
+#[derive(Debug, Default)]
+pub struct ListDevicesResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<DeviceSummaryDecoder>>>>,
+}
+impl_message_decode!(
+    ListDevicesResponseDecoder,
+    Result<Vec<DeviceSummary>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for `ListDevices`.
+#[derive(Debug, Default)]
+pub struct ListDevicesResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<DeviceSummaryEncoder>>>>,
+    >,
+}
+impl_message_encode!(
+    ListDevicesResponseEncoder,
+    Result<Vec<DeviceSummary>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `GetDevice`.
+#[derive(Debug, Default)]
+pub struct GetDeviceResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<DeviceDecoder>>>>,
+}
+impl_message_decode!(GetDeviceResponseDecoder, Result<Option<Device>>, |t: _| Ok(
+    t
+));
+
+/// Encoder for `GetDevice`.
+#[derive(Debug, Default)]
+pub struct GetDeviceResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<DeviceEncoder>>>>,
+}
+impl_sized_message_encode!(
+    GetDeviceResponseEncoder,
+    Result<Option<Device>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `PutDevice`.
+#[derive(Debug, Default)]
+pub struct PutDeviceResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<DeviceDecoder>>>,
+}
+impl_message_decode!(PutDeviceResponseDecoder, Result<Device>, |t: _| Ok(t));
+
+/// Encoder for `PutDevice`.
+#[derive(Debug, Default)]
+pub struct PutDeviceResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<DeviceEncoder>>>,
+}
+impl_sized_message_encode!(
+    PutDeviceResponseEncoder,
+    Result<Device>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `DeleteDevice`.
+#[derive(Debug, Default)]
+pub struct DeleteDeviceResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<DeviceDecoder>>>>,
+}
+impl_message_decode!(
+    DeleteDeviceResponseDecoder,
+    Result<Option<Device>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for `DeleteDevice`.
+#[derive(Debug, Default)]
+pub struct DeleteDeviceResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<DeviceEncoder>>>>,
+}
+impl_sized_message_encode!(
+    DeleteDeviceResponseEncoder,
+    Result<Option<Device>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `ListBuckets`.
+#[derive(Debug, Default)]
+pub struct ListBucketsResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<BucketSummaryDecoder>>>>,
+}
+impl_message_decode!(
+    ListBucketsResponseDecoder,
+    Result<Vec<BucketSummary>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for `ListBuckets`.
+#[derive(Debug, Default)]
+pub struct ListBucketsResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<BucketSummaryEncoder>>>>,
+    >,
+}
+impl_message_encode!(
+    ListBucketsResponseEncoder,
+    Result<Vec<BucketSummary>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `GetBucket`.
+#[derive(Debug, Default)]
+pub struct GetBucketResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<BucketDecoder>>>>,
+}
+impl_message_decode!(GetBucketResponseDecoder, Result<Option<Bucket>>, |t: _| Ok(
+    t
+));
+
+/// Encoder for `GetBucket`.
+#[derive(Debug, Default)]
+pub struct GetBucketResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<BucketEncoder>>>>,
+}
+impl_sized_message_encode!(
+    GetBucketResponseEncoder,
+    Result<Option<Bucket>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `PutBucket`.
+#[derive(Debug, Default)]
+pub struct PutBucketResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<BucketDecoder>>>,
+}
+impl_message_decode!(PutBucketResponseDecoder, Result<Bucket>, |t: _| Ok(t));
+
+/// Encoder for `PutBucket`.
+#[derive(Debug, Default)]
+pub struct PutBucketResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<BucketEncoder>>>,
+}
+impl_sized_message_encode!(
+    PutBucketResponseEncoder,
+    Result<Bucket>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `DeleteBucket`.
+#[derive(Debug, Default)]
+pub struct DeleteBucketResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<BucketDecoder>>>>,
+}
+impl_message_decode!(
+    DeleteBucketResponseDecoder,
+    Result<Option<Bucket>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for `DeleteBucket`.
+#[derive(Debug, Default)]
+pub struct DeleteBucketResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<BucketEncoder>>>>,
+}
+impl_sized_message_encode!(
+    DeleteBucketResponseEncoder,
+    Result<Option<Bucket>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for `GetLeader`.
+#[derive(Debug, Default)]
+pub struct GetLeaderResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<SocketAddrDecoder>>>,
+}
+impl_message_decode!(GetLeaderResponseDecoder, Result<SocketAddr>, |t: _| Ok(t));
+
+/// Encoder for `GetLeader`.
+#[derive(Debug, Default)]
+pub struct GetLeaderResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<SocketAddrEncoder>>>,
+}
+impl_sized_message_encode!(
+    GetLeaderResponseEncoder,
+    Result<SocketAddr>,
+    |item: Self::Item| item
+);

--- a/src/protobuf/schema/config.rs
+++ b/src/protobuf/schema/config.rs
@@ -1,4 +1,6 @@
-//! test
+//! Decoders and encoders for [`libfrugalos::schema::config`](../../schema/config/index.html).
+//!
+//! `package libfrugalos.protobuf.schema.config`.
 
 use bytecodec::combinator::PreEncode;
 use protobuf_codec::field::num::F1;

--- a/src/protobuf/schema/config.rs
+++ b/src/protobuf/schema/config.rs
@@ -2,15 +2,6 @@
 //!
 //! `package libfrugalos.protobuf.schema.config`.
 
-use bytecodec::combinator::PreEncode;
-use protobuf_codec::field::num::F1;
-use protobuf_codec::field::{MessageFieldDecoder, MessageFieldEncoder};
-use protobuf_codec::message::{MessageDecoder, MessageEncoder};
-use std::net::SocketAddr;
-
-use entity::bucket::{Bucket, BucketSummary};
-use entity::device::{Device, DeviceSummary};
-use entity::server::{Server, ServerSummary};
 use protobuf::entity::bucket::{
     BucketDecoder, BucketEncoder, BucketSummaryDecoder, BucketSummaryEncoder,
 };
@@ -24,274 +15,81 @@ use protobuf::net::{SocketAddrDecoder, SocketAddrEncoder};
 use protobuf::{
     OptionDecoder, OptionEncoder, ResultDecoder, ResultEncoder, VecDecoder, VecEncoder,
 };
-use Result;
 
 /// Decoder for `ListServers`.
-#[derive(Debug, Default)]
-pub struct ListServersResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<ServerSummaryDecoder>>>>,
-}
-impl_message_decode!(
-    ListServersResponseDecoder,
-    Result<Vec<ServerSummary>>,
-    |t: _| Ok(t)
-);
+pub type ListServersResponseDecoder = ResultDecoder<VecDecoder<ServerSummaryDecoder>>;
 
 /// Encoder for `ListServers`.
-#[derive(Debug, Default)]
-pub struct ListServersResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<ServerSummaryEncoder>>>>,
-    >,
-}
-impl_message_encode!(
-    ListServersResponseEncoder,
-    Result<Vec<ServerSummary>>,
-    |item: Self::Item| item
-);
+pub type ListServersResponseEncoder = ResultEncoder<VecEncoder<ServerSummaryEncoder>>;
 
 /// Decoder for `GetServer`.
-#[derive(Debug, Default)]
-pub struct GetServerResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<ServerDecoder>>>>,
-}
-impl_message_decode!(GetServerResponseDecoder, Result<Option<Server>>, |t: _| Ok(
-    t
-));
+pub type GetServerResponseDecoder = ResultDecoder<OptionDecoder<ServerDecoder>>;
 
 /// Encoder for `GetServer`.
-#[derive(Debug, Default)]
-pub struct GetServerResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<ServerEncoder>>>>,
-}
-impl_sized_message_encode!(
-    GetServerResponseEncoder,
-    Result<Option<Server>>,
-    |item: Self::Item| item
-);
+pub type GetServerResponseEncoder = ResultEncoder<OptionEncoder<ServerEncoder>>;
 
 /// Decoder for `PutServer`.
-#[derive(Debug, Default)]
-pub struct PutServerResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<ServerDecoder>>>,
-}
-impl_message_decode!(PutServerResponseDecoder, Result<Server>, |t: _| Ok(t));
+pub type PutServerResponseDecoder = ResultDecoder<ServerDecoder>;
 
 /// Encoder for `PutServer`.
-#[derive(Debug, Default)]
-pub struct PutServerResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<ServerEncoder>>>,
-}
-impl_sized_message_encode!(
-    PutServerResponseEncoder,
-    Result<Server>,
-    |item: Self::Item| item
-);
+pub type PutServerResponseEncoder = ResultEncoder<ServerEncoder>;
 
 /// Decoder for `DeleteServer`.
-#[derive(Debug, Default)]
-pub struct DeleteServerResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<ServerDecoder>>>>,
-}
-impl_message_decode!(
-    DeleteServerResponseDecoder,
-    Result<Option<Server>>,
-    |t: _| Ok(t)
-);
+pub type DeleteServerResponseDecoder = ResultDecoder<OptionDecoder<ServerDecoder>>;
 
 /// Encoder for `DeleteServer`.
-#[derive(Debug, Default)]
-pub struct DeleteServerResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<ServerEncoder>>>>,
-}
-impl_sized_message_encode!(
-    DeleteServerResponseEncoder,
-    Result<Option<Server>>,
-    |item: Self::Item| item
-);
+pub type DeleteServerResponseEncoder = ResultEncoder<OptionEncoder<ServerEncoder>>;
 
 /// Decoder for `ListDevices`.
-#[derive(Debug, Default)]
-pub struct ListDevicesResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<DeviceSummaryDecoder>>>>,
-}
-impl_message_decode!(
-    ListDevicesResponseDecoder,
-    Result<Vec<DeviceSummary>>,
-    |t: _| Ok(t)
-);
+pub type ListDevicesResponseDecoder = ResultDecoder<VecDecoder<DeviceSummaryDecoder>>;
 
 /// Encoder for `ListDevices`.
-#[derive(Debug, Default)]
-pub struct ListDevicesResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<DeviceSummaryEncoder>>>>,
-    >,
-}
-impl_message_encode!(
-    ListDevicesResponseEncoder,
-    Result<Vec<DeviceSummary>>,
-    |item: Self::Item| item
-);
+pub type ListDevicesResponseEncoder = ResultEncoder<VecEncoder<DeviceSummaryEncoder>>;
 
 /// Decoder for `GetDevice`.
-#[derive(Debug, Default)]
-pub struct GetDeviceResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<DeviceDecoder>>>>,
-}
-impl_message_decode!(GetDeviceResponseDecoder, Result<Option<Device>>, |t: _| Ok(
-    t
-));
+pub type GetDeviceResponseDecoder = ResultDecoder<OptionDecoder<DeviceDecoder>>;
 
 /// Encoder for `GetDevice`.
-#[derive(Debug, Default)]
-pub struct GetDeviceResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<DeviceEncoder>>>>,
-}
-impl_sized_message_encode!(
-    GetDeviceResponseEncoder,
-    Result<Option<Device>>,
-    |item: Self::Item| item
-);
+pub type GetDeviceResponseEncoder = ResultEncoder<OptionEncoder<DeviceEncoder>>;
 
 /// Decoder for `PutDevice`.
-#[derive(Debug, Default)]
-pub struct PutDeviceResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<DeviceDecoder>>>,
-}
-impl_message_decode!(PutDeviceResponseDecoder, Result<Device>, |t: _| Ok(t));
+pub type PutDeviceResponseDecoder = ResultDecoder<DeviceDecoder>;
 
 /// Encoder for `PutDevice`.
-#[derive(Debug, Default)]
-pub struct PutDeviceResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<DeviceEncoder>>>,
-}
-impl_sized_message_encode!(
-    PutDeviceResponseEncoder,
-    Result<Device>,
-    |item: Self::Item| item
-);
+pub type PutDeviceResponseEncoder = ResultEncoder<DeviceEncoder>;
 
 /// Decoder for `DeleteDevice`.
-#[derive(Debug, Default)]
-pub struct DeleteDeviceResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<DeviceDecoder>>>>,
-}
-impl_message_decode!(
-    DeleteDeviceResponseDecoder,
-    Result<Option<Device>>,
-    |t: _| Ok(t)
-);
+pub type DeleteDeviceResponseDecoder = ResultDecoder<OptionDecoder<DeviceDecoder>>;
 
 /// Encoder for `DeleteDevice`.
-#[derive(Debug, Default)]
-pub struct DeleteDeviceResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<DeviceEncoder>>>>,
-}
-impl_sized_message_encode!(
-    DeleteDeviceResponseEncoder,
-    Result<Option<Device>>,
-    |item: Self::Item| item
-);
+pub type DeleteDeviceResponseEncoder = ResultEncoder<OptionEncoder<DeviceEncoder>>;
 
 /// Decoder for `ListBuckets`.
-#[derive(Debug, Default)]
-pub struct ListBucketsResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<BucketSummaryDecoder>>>>,
-}
-impl_message_decode!(
-    ListBucketsResponseDecoder,
-    Result<Vec<BucketSummary>>,
-    |t: _| Ok(t)
-);
+pub type ListBucketsResponseDecoder = ResultDecoder<VecDecoder<BucketSummaryDecoder>>;
 
 /// Encoder for `ListBuckets`.
-#[derive(Debug, Default)]
-pub struct ListBucketsResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<BucketSummaryEncoder>>>>,
-    >,
-}
-impl_message_encode!(
-    ListBucketsResponseEncoder,
-    Result<Vec<BucketSummary>>,
-    |item: Self::Item| item
-);
+pub type ListBucketsResponseEncoder = ResultEncoder<VecEncoder<BucketSummaryEncoder>>;
 
 /// Decoder for `GetBucket`.
-#[derive(Debug, Default)]
-pub struct GetBucketResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<BucketDecoder>>>>,
-}
-impl_message_decode!(GetBucketResponseDecoder, Result<Option<Bucket>>, |t: _| Ok(
-    t
-));
+pub type GetBucketResponseDecoder = ResultDecoder<OptionDecoder<BucketDecoder>>;
 
 /// Encoder for `GetBucket`.
-#[derive(Debug, Default)]
-pub struct GetBucketResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<BucketEncoder>>>>,
-}
-impl_sized_message_encode!(
-    GetBucketResponseEncoder,
-    Result<Option<Bucket>>,
-    |item: Self::Item| item
-);
+pub type GetBucketResponseEncoder = ResultEncoder<OptionEncoder<BucketEncoder>>;
 
 /// Decoder for `PutBucket`.
-#[derive(Debug, Default)]
-pub struct PutBucketResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<BucketDecoder>>>,
-}
-impl_message_decode!(PutBucketResponseDecoder, Result<Bucket>, |t: _| Ok(t));
+pub type PutBucketResponseDecoder = ResultDecoder<BucketDecoder>;
 
 /// Encoder for `PutBucket`.
-#[derive(Debug, Default)]
-pub struct PutBucketResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<BucketEncoder>>>,
-}
-impl_sized_message_encode!(
-    PutBucketResponseEncoder,
-    Result<Bucket>,
-    |item: Self::Item| item
-);
+pub type PutBucketResponseEncoder = ResultEncoder<BucketEncoder>;
 
 /// Decoder for `DeleteBucket`.
-#[derive(Debug, Default)]
-pub struct DeleteBucketResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<BucketDecoder>>>>,
-}
-impl_message_decode!(
-    DeleteBucketResponseDecoder,
-    Result<Option<Bucket>>,
-    |t: _| Ok(t)
-);
+pub type DeleteBucketResponseDecoder = ResultDecoder<OptionDecoder<BucketDecoder>>;
 
 /// Encoder for `DeleteBucket`.
-#[derive(Debug, Default)]
-pub struct DeleteBucketResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<BucketEncoder>>>>,
-}
-impl_sized_message_encode!(
-    DeleteBucketResponseEncoder,
-    Result<Option<Bucket>>,
-    |item: Self::Item| item
-);
+pub type DeleteBucketResponseEncoder = ResultEncoder<OptionEncoder<BucketEncoder>>;
 
 /// Decoder for `GetLeader`.
-#[derive(Debug, Default)]
-pub struct GetLeaderResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<SocketAddrDecoder>>>,
-}
-impl_message_decode!(GetLeaderResponseDecoder, Result<SocketAddr>, |t: _| Ok(t));
+pub type GetLeaderResponseDecoder = ResultDecoder<SocketAddrDecoder>;
 
 /// Encoder for `GetLeader`.
-#[derive(Debug, Default)]
-pub struct GetLeaderResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<SocketAddrEncoder>>>,
-}
-impl_sized_message_encode!(
-    GetLeaderResponseEncoder,
-    Result<SocketAddr>,
-    |item: Self::Item| item
-);
+pub type GetLeaderResponseEncoder = ResultEncoder<SocketAddrEncoder>;

--- a/src/protobuf/schema/config.rs
+++ b/src/protobuf/schema/config.rs
@@ -16,80 +16,80 @@ use protobuf::{
     OptionDecoder, OptionEncoder, ResultDecoder, ResultEncoder, VecDecoder, VecEncoder,
 };
 
-/// Decoder for `ListServers`.
+/// Decoder for `ListServersRpc`.
 pub type ListServersResponseDecoder = ResultDecoder<VecDecoder<ServerSummaryDecoder>>;
 
-/// Encoder for `ListServers`.
+/// Encoder for `ListServersRpc`.
 pub type ListServersResponseEncoder = ResultEncoder<VecEncoder<ServerSummaryEncoder>>;
 
-/// Decoder for `GetServer`.
+/// Decoder for `GetServerRpc`.
 pub type GetServerResponseDecoder = ResultDecoder<OptionDecoder<ServerDecoder>>;
 
-/// Encoder for `GetServer`.
+/// Encoder for `GetServerRpc`.
 pub type GetServerResponseEncoder = ResultEncoder<OptionEncoder<ServerEncoder>>;
 
-/// Decoder for `PutServer`.
+/// Decoder for `PutServerRpc`.
 pub type PutServerResponseDecoder = ResultDecoder<ServerDecoder>;
 
-/// Encoder for `PutServer`.
+/// Encoder for `PutServerRpc`.
 pub type PutServerResponseEncoder = ResultEncoder<ServerEncoder>;
 
-/// Decoder for `DeleteServer`.
+/// Decoder for `DeleteServerRpc`.
 pub type DeleteServerResponseDecoder = ResultDecoder<OptionDecoder<ServerDecoder>>;
 
-/// Encoder for `DeleteServer`.
+/// Encoder for `DeleteServerRpc`.
 pub type DeleteServerResponseEncoder = ResultEncoder<OptionEncoder<ServerEncoder>>;
 
-/// Decoder for `ListDevices`.
+/// Decoder for `ListDevicesRpc`.
 pub type ListDevicesResponseDecoder = ResultDecoder<VecDecoder<DeviceSummaryDecoder>>;
 
-/// Encoder for `ListDevices`.
+/// Encoder for `ListDevicesRpc`.
 pub type ListDevicesResponseEncoder = ResultEncoder<VecEncoder<DeviceSummaryEncoder>>;
 
-/// Decoder for `GetDevice`.
+/// Decoder for `GetDeviceRpc`.
 pub type GetDeviceResponseDecoder = ResultDecoder<OptionDecoder<DeviceDecoder>>;
 
-/// Encoder for `GetDevice`.
+/// Encoder for `GetDeviceRpc`.
 pub type GetDeviceResponseEncoder = ResultEncoder<OptionEncoder<DeviceEncoder>>;
 
-/// Decoder for `PutDevice`.
+/// Decoder for `PutDeviceRpc`.
 pub type PutDeviceResponseDecoder = ResultDecoder<DeviceDecoder>;
 
-/// Encoder for `PutDevice`.
+/// Encoder for `PutDeviceRpc`.
 pub type PutDeviceResponseEncoder = ResultEncoder<DeviceEncoder>;
 
-/// Decoder for `DeleteDevice`.
+/// Decoder for `DeleteDeviceRpc`.
 pub type DeleteDeviceResponseDecoder = ResultDecoder<OptionDecoder<DeviceDecoder>>;
 
-/// Encoder for `DeleteDevice`.
+/// Encoder for `DeleteDeviceRpc`.
 pub type DeleteDeviceResponseEncoder = ResultEncoder<OptionEncoder<DeviceEncoder>>;
 
-/// Decoder for `ListBuckets`.
+/// Decoder for `ListBucketsRpc`.
 pub type ListBucketsResponseDecoder = ResultDecoder<VecDecoder<BucketSummaryDecoder>>;
 
-/// Encoder for `ListBuckets`.
+/// Encoder for `ListBucketsRpc`.
 pub type ListBucketsResponseEncoder = ResultEncoder<VecEncoder<BucketSummaryEncoder>>;
 
-/// Decoder for `GetBucket`.
+/// Decoder for `GetBucketRpc`.
 pub type GetBucketResponseDecoder = ResultDecoder<OptionDecoder<BucketDecoder>>;
 
-/// Encoder for `GetBucket`.
+/// Encoder for `GetBucketRpc`.
 pub type GetBucketResponseEncoder = ResultEncoder<OptionEncoder<BucketEncoder>>;
 
-/// Decoder for `PutBucket`.
+/// Decoder for `PutBucketRpc`.
 pub type PutBucketResponseDecoder = ResultDecoder<BucketDecoder>;
 
-/// Encoder for `PutBucket`.
+/// Encoder for `PutBucketRpc`.
 pub type PutBucketResponseEncoder = ResultEncoder<BucketEncoder>;
 
-/// Decoder for `DeleteBucket`.
+/// Decoder for `DeleteBucketRpc`.
 pub type DeleteBucketResponseDecoder = ResultDecoder<OptionDecoder<BucketDecoder>>;
 
-/// Encoder for `DeleteBucket`.
+/// Encoder for `DeleteBucketRpc`.
 pub type DeleteBucketResponseEncoder = ResultEncoder<OptionEncoder<BucketEncoder>>;
 
-/// Decoder for `GetLeader`.
+/// Decoder for `GetLeaderRpc`.
 pub type GetLeaderResponseDecoder = ResultDecoder<SocketAddrDecoder>;
 
-/// Encoder for `GetLeader`.
+/// Encoder for `GetLeaderRpc`.
 pub type GetLeaderResponseEncoder = ResultEncoder<SocketAddrEncoder>;

--- a/src/protobuf/schema/frugalos.rs
+++ b/src/protobuf/schema/frugalos.rs
@@ -1,4 +1,6 @@
-//! test
+//! Decoders and encoders for [`libfrugalos::schema::frugalos`](../../schema/frugalos/index.html).
+//!
+//! `package libfrugalos.protobuf.schema.frugalos`.
 
 use bytecodec::combinator::PreEncode;
 use protobuf_codec::field::num::{F1, F2, F3, F4, F5, F6};

--- a/src/protobuf/schema/frugalos.rs
+++ b/src/protobuf/schema/frugalos.rs
@@ -16,7 +16,7 @@ use protobuf_codec::scalar::{
 
 use entity::bucket::BucketId;
 use entity::device::DeviceId;
-use entity::object::{FragmentsSummary, ObjectId, ObjectVersion};
+use entity::object::{ObjectId, ObjectVersion};
 use protobuf::consistency::{ReadConsistencyDecoder, ReadConsistencyEncoder};
 use protobuf::deadline::{decode_deadline, encode_deadline, DeadlineDecoder, DeadlineEncoder};
 use protobuf::entity::bucket::{BucketIdDecoder, BucketIdEncoder};
@@ -512,18 +512,13 @@ impl_message_encode!(
 /// Decoder for a response of `GetObject`.
 #[derive(Debug, Default)]
 pub struct GetObjectResponseDecoder {
-    inner: MessageDecoder<
-        MessageFieldDecoder<
-            F1,
-            ResultDecoder<
-                OptionDecoder<
-                    MessageDecoder<
-                        Fields<(
-                            MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
-                            MaybeDefault<FieldDecoder<F2, BytesDecoder>>,
-                        )>,
-                    >,
-                >,
+    inner: ResultDecoder<
+        OptionDecoder<
+            MessageDecoder<
+                Fields<(
+                    MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
+                    MaybeDefault<FieldDecoder<F2, BytesDecoder>>,
+                )>,
             >,
         >,
     >,
@@ -537,18 +532,13 @@ impl_message_decode!(
 /// Encoder for a response of `GetObject`.
 #[derive(Debug, Default)]
 pub struct GetObjectResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<
-            F1,
-            ResultEncoder<
-                OptionEncoder<
-                    MessageEncoder<
-                        Fields<(
-                            FieldEncoder<F1, ObjectVersionEncoder>,
-                            FieldEncoder<F2, BytesEncoder>,
-                        )>,
-                    >,
-                >,
+    inner: ResultEncoder<
+        OptionEncoder<
+            MessageEncoder<
+                Fields<(
+                    FieldEncoder<F1, ObjectVersionEncoder>,
+                    FieldEncoder<F2, BytesEncoder>,
+                )>,
             >,
         >,
     >,
@@ -562,17 +552,12 @@ impl_sized_message_encode!(
 /// Decoder for a response of `PutObject`.
 #[derive(Debug, Default)]
 pub struct PutObjectResponseDecoder {
-    inner: MessageDecoder<
-        MessageFieldDecoder<
-            F1,
-            ResultDecoder<
-                MessageDecoder<
-                    Fields<(
-                        MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
-                        MaybeDefault<FieldDecoder<F2, BoolDecoder>>,
-                    )>,
-                >,
-            >,
+    inner: ResultDecoder<
+        MessageDecoder<
+            Fields<(
+                MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
+                MaybeDefault<FieldDecoder<F2, BoolDecoder>>,
+            )>,
         >,
     >,
 }
@@ -585,17 +570,12 @@ impl_message_decode!(
 /// Encoder for a response of `PutObject`.
 #[derive(Debug, Default)]
 pub struct PutObjectResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<
-            F1,
-            ResultEncoder<
-                MessageEncoder<
-                    Fields<(
-                        FieldEncoder<F1, ObjectVersionEncoder>,
-                        FieldEncoder<F2, BoolEncoder>,
-                    )>,
-                >,
-            >,
+    inner: ResultEncoder<
+        MessageEncoder<
+            Fields<(
+                FieldEncoder<F1, ObjectVersionEncoder>,
+                FieldEncoder<F2, BoolEncoder>,
+            )>,
         >,
     >,
 }
@@ -606,73 +586,31 @@ impl_sized_message_encode!(
 );
 
 /// Decoder for a response of `CountFragments`.
-#[derive(Debug, Default)]
-pub struct CountFragmentsResponseDecoder {
-    inner: MessageDecoder<
-        MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<FragmentsSummaryDecoder>>>,
-    >,
-}
-impl_message_decode!(
-    CountFragmentsResponseDecoder,
-    Result<Option<FragmentsSummary>>,
-    |r: Result<Option<FragmentsSummary>>| Ok(r)
-);
+pub type CountFragmentsResponseDecoder = ResultDecoder<OptionDecoder<FragmentsSummaryDecoder>>;
 
 /// Encoder for a response of `CountFragments`.
-#[derive(Debug, Default)]
-pub struct CountFragmentsResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<FragmentsSummaryEncoder>>>,
-    >,
-}
-impl_sized_message_encode!(
-    CountFragmentsResponseEncoder,
-    Result<Option<FragmentsSummary>>,
-    |item: Self::Item| item
-);
-
-/// Decoder for a response of `Stop`.
-#[derive(Debug, Default)]
-pub struct StopResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<EmptyMessageDecoder>>>,
-}
-impl_message_decode!(StopResponseDecoder, Result<()>, |r: _| Ok(r));
-
-/// Encoder for a response of `Stop`.
-#[derive(Debug, Default)]
-pub struct StopResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<EmptyMessageEncoder>>>,
-}
-impl_sized_message_encode!(StopResponseEncoder, Result<()>, |item: Self::Item| item);
-
-/// Decoder for a response of `TakeSnapshot`.
-#[derive(Debug, Default)]
-pub struct TakeSnapshotResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<EmptyMessageDecoder>>>,
-}
-impl_message_decode!(TakeSnapshotResponseDecoder, Result<()>, |r: _| Ok(r));
-
-/// Encoder for a response of `TakeSnapshot`.
-#[derive(Debug, Default)]
-pub struct TakeSnapshotResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<EmptyMessageEncoder>>>,
-}
-impl_sized_message_encode!(
-    TakeSnapshotResponseEncoder,
-    Result<()>,
-    |item: Self::Item| item
-);
+pub type CountFragmentsResponseEncoder = ResultEncoder<OptionEncoder<FragmentsSummaryEncoder>>;
 
 /// Decoder for a response of `Empty`.
-#[derive(Debug, Default)]
-pub struct EmptyResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<EmptyMessageDecoder>>>,
-}
-impl_message_decode!(EmptyResponseDecoder, Result<()>, |r: _| Ok(r));
+pub type DeleteObjectSetFromDeviceResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
 
 /// Encoder for a response of `Empty`.
-#[derive(Debug, Default)]
-pub struct EmptyResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<EmptyMessageEncoder>>>,
-}
-impl_sized_message_encode!(EmptyResponseEncoder, Result<()>, |item: Self::Item| item);
+pub type DeleteObjectSetFromDeviceResponseEncoder = ResultEncoder<EmptyMessageEncoder>;
+
+/// Decoder for a response of `Stop`.
+pub type StopResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
+
+/// Encoder for a response of `Stop`.
+pub type StopResponseEncoder = ResultEncoder<EmptyMessageEncoder>;
+
+/// Decoder for a response of `TakeSnapshot`.
+pub type TakeSnapshotResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
+
+/// Encoder for a response of `TakeSnapshot`.
+pub type TakeSnapshotResponseEncoder = ResultEncoder<EmptyMessageEncoder>;
+
+/// Decoder for a response of `Empty`.
+pub type SetRepairConfigResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
+
+/// Encoder for a response of `Empty`.
+pub type SetRepairConfigResponseEncoder = ResultEncoder<EmptyMessageEncoder>;

--- a/src/protobuf/schema/frugalos.rs
+++ b/src/protobuf/schema/frugalos.rs
@@ -27,6 +27,7 @@ use protobuf::entity::object::{
     ObjectVersionDecoder, ObjectVersionEncoder,
 };
 use protobuf::expect::{ExpectDecoder, ExpectEncoder};
+use protobuf::multiplicity::{MultiplicityConfigDecoder, MultiplicityConfigEncoder};
 use protobuf::{OptionDecoder, OptionEncoder, ResultDecoder, ResultEncoder};
 use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMessageEncoder};
 use schema::frugalos::{
@@ -341,7 +342,7 @@ pub struct PutObjectRequestDecoder {
             MaybeDefault<FieldDecoder<F3, BytesDecoder>>,
             MessageFieldDecoder<F4, DeadlineDecoder>,
             MessageFieldDecoder<F5, ExpectDecoder>,
-            FieldDecoder<F6, Uint32Decoder>, // TODO
+            MessageFieldDecoder<F6, MultiplicityConfigDecoder>,
         )>,
     >,
 }
@@ -360,7 +361,7 @@ impl_message_decode!(PutObjectRequestDecoder, PutObjectRequest, |t: (
         content: t.2,
         deadline,
         expect: t.4,
-        multiplicity_config: Default::default(), // TODO
+        multiplicity_config: t.5,
     })
 });
 
@@ -374,7 +375,7 @@ pub struct PutObjectRequestEncoder {
             FieldEncoder<F3, BytesEncoder>,
             MessageFieldEncoder<F4, DeadlineEncoder>,
             MessageFieldEncoder<F5, PreEncode<ExpectEncoder>>,
-            FieldEncoder<F6, Uint32Encoder>, // TODO
+            MessageFieldEncoder<F6, MultiplicityConfigEncoder>,
         )>,
     >,
 }
@@ -388,7 +389,7 @@ impl_sized_message_encode!(
             item.content,
             encode_deadline(item.deadline),
             item.expect,
-            Default::default(), // TODO
+            item.multiplicity_config,
         )
     }
 );

--- a/src/protobuf/schema/frugalos.rs
+++ b/src/protobuf/schema/frugalos.rs
@@ -1,0 +1,676 @@
+//! test
+
+use bytecodec::combinator::PreEncode;
+use protobuf_codec::field::num::{F1, F2, F3, F4, F5, F6};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, Fields, MaybeDefault, MessageFieldDecoder, MessageFieldEncoder,
+    Optional, Repeated,
+};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{
+    BoolDecoder, BoolEncoder, BytesDecoder, BytesEncoder, StringDecoder, StringEncoder,
+    Uint32Decoder, Uint32Encoder,
+};
+
+use entity::bucket::BucketId;
+use entity::device::DeviceId;
+use entity::object::{FragmentsSummary, ObjectId, ObjectVersion};
+use protobuf::consistency::{ReadConsistencyDecoder, ReadConsistencyEncoder};
+use protobuf::deadline::{decode_deadline, encode_deadline, DeadlineDecoder, DeadlineEncoder};
+use protobuf::entity::bucket::{BucketIdDecoder, BucketIdEncoder};
+use protobuf::entity::device::{DeviceIdDecoder, DeviceIdEncoder};
+use protobuf::entity::object::{
+    FragmentsSummaryDecoder, FragmentsSummaryEncoder, ObjectIdDecoder, ObjectIdEncoder,
+    ObjectPrefixDecoder, ObjectPrefixEncoder, ObjectRangeDecoder, ObjectRangeEncoder,
+    ObjectVersionDecoder, ObjectVersionEncoder,
+};
+use protobuf::expect::{ExpectDecoder, ExpectEncoder};
+use protobuf::{OptionDecoder, OptionEncoder, ResultDecoder, ResultEncoder};
+use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMessageEncoder};
+use schema::frugalos::{
+    CountFragmentsRequest, DeleteObjectSetFromDeviceRequest, HeadObjectRequest, ListObjectsRequest,
+    ObjectRequest, PrefixRequest, PutObjectRequest, RangeRequest, SegmentRequest, VersionRequest,
+};
+use Result;
+
+/// Decoder for `ObjectRequest`.
+#[derive(Debug, Default)]
+pub struct ObjectRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, StringDecoder>>,
+            MessageFieldDecoder<F3, DeadlineDecoder>,
+            MessageFieldDecoder<F4, ExpectDecoder>,
+            Optional<MessageFieldDecoder<F5, ReadConsistencyDecoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(ObjectRequestDecoder, ObjectRequest, |t: (
+    String,
+    String,
+    _,
+    _,
+    _,
+)| {
+    let deadline = track!(decode_deadline(t.2))?;
+    Ok(ObjectRequest {
+        bucket_id: t.0.clone(),
+        object_id: t.1.clone(),
+        deadline,
+        expect: t.3,
+        consistency: t.4,
+    })
+});
+
+/// Encoder for `ObjectRequest`.
+#[derive(Debug, Default)]
+pub struct ObjectRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, StringEncoder>,
+            MessageFieldEncoder<F3, DeadlineEncoder>,
+            MessageFieldEncoder<F4, PreEncode<ExpectEncoder>>,
+            Optional<MessageFieldEncoder<F5, ReadConsistencyEncoder>>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(ObjectRequestEncoder, ObjectRequest, |item: Self::Item| {
+    (
+        item.bucket_id,
+        item.object_id,
+        encode_deadline(item.deadline),
+        item.expect,
+        item.consistency,
+    )
+});
+
+/// Decoder for `CountFragmentsRequest`.
+#[derive(Debug, Default)]
+pub struct CountFragmentsRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, ObjectIdDecoder>>,
+            MessageFieldDecoder<F3, DeadlineDecoder>,
+            MessageFieldDecoder<F4, ExpectDecoder>,
+            MessageFieldDecoder<F5, ReadConsistencyDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(
+    CountFragmentsRequestDecoder,
+    CountFragmentsRequest,
+    |t: (String, String, _, _, _,)| {
+        let deadline = track!(decode_deadline(t.2))?;
+        Ok(CountFragmentsRequest {
+            bucket_id: t.0.clone(),
+            object_id: t.1.clone(),
+            deadline,
+            expect: t.3,
+            consistency: t.4,
+        })
+    }
+);
+
+/// Encoder for `CountFragmentsRequest`.
+#[derive(Debug, Default)]
+pub struct CountFragmentsRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, ObjectIdEncoder>,
+            MessageFieldEncoder<F3, DeadlineEncoder>,
+            MessageFieldEncoder<F4, PreEncode<ExpectEncoder>>,
+            MessageFieldEncoder<F5, ReadConsistencyEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    CountFragmentsRequestEncoder,
+    CountFragmentsRequest,
+    |item: Self::Item| {
+        (
+            item.bucket_id,
+            item.object_id,
+            encode_deadline(item.deadline),
+            item.expect,
+            item.consistency,
+        )
+    }
+);
+
+/// Decoder for `HeadObjectRequest`.
+#[derive(Debug, Default)]
+pub struct HeadObjectRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, ObjectIdDecoder>>,
+            MessageFieldDecoder<F3, DeadlineDecoder>,
+            MessageFieldDecoder<F4, ExpectDecoder>,
+            MessageFieldDecoder<F5, ReadConsistencyDecoder>,
+            MaybeDefault<FieldDecoder<F6, BoolDecoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(HeadObjectRequestDecoder, HeadObjectRequest, |t: (
+    String,
+    String,
+    _,
+    _,
+    _,
+    _,
+)| {
+    let deadline = track!(decode_deadline(t.2))?;
+    Ok(HeadObjectRequest {
+        bucket_id: t.0.clone(),
+        object_id: t.1.clone(),
+        deadline,
+        expect: t.3,
+        consistency: t.4,
+        check_storage: t.5,
+    })
+});
+
+/// Encoder for `HeadObjectRequest`.
+#[derive(Debug, Default)]
+pub struct HeadObjectRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, ObjectIdEncoder>,
+            MessageFieldEncoder<F3, DeadlineEncoder>,
+            MessageFieldEncoder<F4, PreEncode<ExpectEncoder>>,
+            MessageFieldEncoder<F5, ReadConsistencyEncoder>,
+            FieldEncoder<F6, BoolEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    HeadObjectRequestEncoder,
+    HeadObjectRequest,
+    |item: Self::Item| {
+        (
+            item.bucket_id,
+            item.object_id,
+            encode_deadline(item.deadline),
+            item.expect,
+            item.consistency,
+            item.check_storage,
+        )
+    }
+);
+
+/// Decoder for `VersionRequest`.
+#[derive(Debug, Default)]
+pub struct VersionRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, Uint32Decoder>>,
+            MaybeDefault<FieldDecoder<F3, ObjectVersionDecoder>>,
+            MessageFieldDecoder<F4, DeadlineDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(VersionRequestDecoder, VersionRequest, |t: (
+    String,
+    _,
+    _,
+    _,
+)| {
+    let deadline = track!(decode_deadline(t.3))?;
+    Ok(VersionRequest {
+        bucket_id: t.0.clone(),
+        segment: t.1 as u16,
+        object_version: ObjectVersion(t.2),
+        deadline,
+    })
+});
+
+/// Encoder for `VersionRequest`.
+#[derive(Debug, Default)]
+pub struct VersionRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, Uint32Encoder>,
+            FieldEncoder<F3, ObjectVersionEncoder>,
+            MessageFieldEncoder<F4, DeadlineEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(VersionRequestEncoder, VersionRequest, |item: Self::Item| {
+    (
+        item.bucket_id,
+        item.segment as u32,
+        item.object_version.0,
+        encode_deadline(item.deadline),
+    )
+});
+
+/// Decoder for `RangeRequest`.
+#[derive(Debug, Default)]
+pub struct RangeRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, Uint32Decoder>>,
+            MessageFieldDecoder<F3, ObjectRangeDecoder>,
+            MessageFieldDecoder<F4, DeadlineDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(RangeRequestDecoder, RangeRequest, |t: (String, _, _, _,)| {
+    let deadline = track!(decode_deadline(t.3))?;
+    Ok(RangeRequest {
+        bucket_id: t.0.clone(),
+        segment: t.1 as u16,
+        targets: t.2,
+        deadline,
+    })
+});
+
+/// Encoder for `RangeRequest`.
+#[derive(Debug, Default)]
+pub struct RangeRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, Uint32Encoder>,
+            MessageFieldEncoder<F3, ObjectRangeEncoder>,
+            MessageFieldEncoder<F4, DeadlineEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(RangeRequestEncoder, RangeRequest, |item: Self::Item| {
+    (
+        item.bucket_id,
+        item.segment as u32,
+        item.targets,
+        encode_deadline(item.deadline),
+    )
+});
+
+/// Decoder for `PrefixRequest`.
+#[derive(Debug, Default)]
+pub struct PrefixRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MessageFieldDecoder<F2, ObjectPrefixDecoder>,
+            MessageFieldDecoder<F3, DeadlineDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(PrefixRequestDecoder, PrefixRequest, |t: (String, _, _,)| {
+    let deadline = track!(decode_deadline(t.2))?;
+    Ok(PrefixRequest {
+        bucket_id: t.0.clone(),
+        prefix: t.1,
+        deadline,
+    })
+});
+
+/// Encoder for `PrefixRequest`.
+#[derive(Debug, Default)]
+pub struct PrefixRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            MessageFieldEncoder<F2, ObjectPrefixEncoder>,
+            MessageFieldEncoder<F3, DeadlineEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(PrefixRequestEncoder, PrefixRequest, |item: Self::Item| {
+    (item.bucket_id, item.prefix, encode_deadline(item.deadline))
+});
+
+/// Decoder for `PutObjectRequest`.
+#[derive(Debug, Default)]
+pub struct PutObjectRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, ObjectIdDecoder>>,
+            MaybeDefault<FieldDecoder<F3, BytesDecoder>>,
+            MessageFieldDecoder<F4, DeadlineDecoder>,
+            MessageFieldDecoder<F5, ExpectDecoder>,
+            FieldDecoder<F6, Uint32Decoder>, // TODO
+        )>,
+    >,
+}
+impl_message_decode!(PutObjectRequestDecoder, PutObjectRequest, |t: (
+    String,
+    String,
+    _,
+    _,
+    _,
+    _,
+)| {
+    let deadline = track!(decode_deadline(t.3))?;
+    Ok(PutObjectRequest {
+        bucket_id: t.0.clone(),
+        object_id: t.1.clone(),
+        content: t.2,
+        deadline,
+        expect: t.4,
+        multiplicity_config: Default::default(), // TODO
+    })
+});
+
+/// Encoder for `PutObjectRequest`.
+#[derive(Debug, Default)]
+pub struct PutObjectRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, ObjectIdEncoder>,
+            FieldEncoder<F3, BytesEncoder>,
+            MessageFieldEncoder<F4, DeadlineEncoder>,
+            MessageFieldEncoder<F5, PreEncode<ExpectEncoder>>,
+            FieldEncoder<F6, Uint32Encoder>, // TODO
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    PutObjectRequestEncoder,
+    PutObjectRequest,
+    |item: Self::Item| {
+        (
+            item.bucket_id,
+            item.object_id,
+            item.content,
+            encode_deadline(item.deadline),
+            item.expect,
+            Default::default(), // TODO
+        )
+    }
+);
+
+/// Decoder for `ListObjectsRequestEncoder`.
+#[derive(Debug, Default)]
+pub struct ListObjectsRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, Uint32Decoder>>,
+            MaybeDefault<MessageFieldDecoder<F3, ReadConsistencyDecoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(ListObjectsRequestDecoder, ListObjectsRequest, |t: (
+    String,
+    _,
+    _
+)| {
+    Ok(ListObjectsRequest {
+        bucket_id: t.0.clone(),
+        segment: t.1 as u16,
+        consistency: t.2,
+    })
+});
+
+/// Encoder for `ListObjectsRequestEncoder`.
+#[derive(Debug, Default)]
+pub struct ListObjectsRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, Uint32Encoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    ListObjectsRequestEncoder,
+    ListObjectsRequest,
+    |t: Self::Item| { (t.bucket_id, t.segment as u32) }
+);
+
+/// Decoder for `SegmentRequest`.
+#[derive(Debug, Default)]
+pub struct SegmentRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            FieldDecoder<F1, BucketIdDecoder>,
+            FieldDecoder<F2, Uint32Decoder>,
+        )>,
+    >,
+}
+impl_message_decode!(SegmentRequestDecoder, SegmentRequest, |t: (String, u32)| {
+    Ok(SegmentRequest {
+        bucket_id: t.0.clone(),
+        segment: t.1 as u16,
+    })
+});
+
+/// Encoder for `SegmentRequest`.
+#[derive(Debug, Default)]
+pub struct SegmentRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, Uint32Encoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(SegmentRequestEncoder, SegmentRequest, |t: Self::Item| {
+    (t.bucket_id, t.segment as u32)
+});
+
+/// Decoder for `DeleteObjectSetFromDeviceRequest`.
+#[derive(Debug, Default)]
+pub struct DeleteObjectSetFromDeviceRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, BucketIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, DeviceIdDecoder>>,
+            Repeated<FieldDecoder<F3, ObjectIdDecoder>, Vec<String>>,
+        )>,
+    >,
+}
+impl_message_decode!(
+    DeleteObjectSetFromDeviceRequestDecoder,
+    DeleteObjectSetFromDeviceRequest,
+    |t: (BucketId, DeviceId, Vec<ObjectId>,)| {
+        Ok(DeleteObjectSetFromDeviceRequest {
+            bucket_id: t.0.clone(),
+            device_id: t.1.clone(),
+            object_ids: t.2.into_iter().collect(),
+        })
+    }
+);
+
+/// Encoder for `DeleteObjectSetFromDeviceRequest`.
+#[derive(Debug, Default)]
+pub struct DeleteObjectSetFromDeviceRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, BucketIdEncoder>,
+            FieldEncoder<F2, DeviceIdEncoder>,
+            Repeated<FieldEncoder<F3, ObjectIdEncoder>, Vec<String>>,
+        )>,
+    >,
+}
+impl_message_encode!(
+    DeleteObjectSetFromDeviceRequestEncoder,
+    DeleteObjectSetFromDeviceRequest,
+    |item: Self::Item| {
+        (
+            item.bucket_id,
+            item.device_id,
+            item.object_ids.into_iter().collect(),
+        )
+    }
+);
+
+/// Decoder for a response of `GetObject`.
+#[derive(Debug, Default)]
+pub struct GetObjectResponseDecoder {
+    inner: MessageDecoder<
+        MessageFieldDecoder<
+            F1,
+            ResultDecoder<
+                OptionDecoder<
+                    MessageDecoder<
+                        Fields<(
+                            MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
+                            MaybeDefault<FieldDecoder<F2, BytesDecoder>>,
+                        )>,
+                    >,
+                >,
+            >,
+        >,
+    >,
+}
+impl_message_decode!(
+    GetObjectResponseDecoder,
+    Result<Option<(ObjectVersion, Vec<u8>)>>,
+    |r: Result<Option<(u64, Vec<u8>)>>| Ok(r.map(|v| v.map(|t| (ObjectVersion(t.0), t.1))))
+);
+
+/// Encoder for a response of `GetObject`.
+#[derive(Debug, Default)]
+pub struct GetObjectResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<
+            F1,
+            ResultEncoder<
+                OptionEncoder<
+                    MessageEncoder<
+                        Fields<(
+                            FieldEncoder<F1, ObjectVersionEncoder>,
+                            FieldEncoder<F2, BytesEncoder>,
+                        )>,
+                    >,
+                >,
+            >,
+        >,
+    >,
+}
+impl_sized_message_encode!(
+    GetObjectResponseEncoder,
+    Result<Option<(ObjectVersion, Vec<u8>)>>,
+    |item: Self::Item| item.map(|v| v.map(|t| ((t.0).0, t.1)))
+);
+
+/// Decoder for a response of `PutObject`.
+#[derive(Debug, Default)]
+pub struct PutObjectResponseDecoder {
+    inner: MessageDecoder<
+        MessageFieldDecoder<
+            F1,
+            ResultDecoder<
+                MessageDecoder<
+                    Fields<(
+                        MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
+                        MaybeDefault<FieldDecoder<F2, BoolDecoder>>,
+                    )>,
+                >,
+            >,
+        >,
+    >,
+}
+impl_message_decode!(
+    PutObjectResponseDecoder,
+    Result<(ObjectVersion, bool)>,
+    |r: Result<(u64, bool)>| Ok(r.map(|t| (ObjectVersion(t.0), t.1)))
+);
+
+/// Encoder for a response of `PutObject`.
+#[derive(Debug, Default)]
+pub struct PutObjectResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<
+            F1,
+            ResultEncoder<
+                MessageEncoder<
+                    Fields<(
+                        FieldEncoder<F1, ObjectVersionEncoder>,
+                        FieldEncoder<F2, BoolEncoder>,
+                    )>,
+                >,
+            >,
+        >,
+    >,
+}
+impl_sized_message_encode!(
+    PutObjectResponseEncoder,
+    Result<(ObjectVersion, bool)>,
+    |item: Self::Item| item.map(|t| ((t.0).0, t.1))
+);
+
+/// Decoder for a response of `CountFragments`.
+#[derive(Debug, Default)]
+pub struct CountFragmentsResponseDecoder {
+    inner: MessageDecoder<
+        MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<FragmentsSummaryDecoder>>>,
+    >,
+}
+impl_message_decode!(
+    CountFragmentsResponseDecoder,
+    Result<Option<FragmentsSummary>>,
+    |r: Result<Option<FragmentsSummary>>| Ok(r)
+);
+
+/// Encoder for a response of `CountFragments`.
+#[derive(Debug, Default)]
+pub struct CountFragmentsResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<FragmentsSummaryEncoder>>>,
+    >,
+}
+impl_sized_message_encode!(
+    CountFragmentsResponseEncoder,
+    Result<Option<FragmentsSummary>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for a response of `Stop`.
+#[derive(Debug, Default)]
+pub struct StopResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<EmptyMessageDecoder>>>,
+}
+impl_message_decode!(StopResponseDecoder, Result<()>, |r: _| Ok(r));
+
+/// Encoder for a response of `Stop`.
+#[derive(Debug, Default)]
+pub struct StopResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<EmptyMessageEncoder>>>,
+}
+impl_sized_message_encode!(StopResponseEncoder, Result<()>, |item: Self::Item| item);
+
+/// Decoder for a response of `TakeSnapshot`.
+#[derive(Debug, Default)]
+pub struct TakeSnapshotResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<EmptyMessageDecoder>>>,
+}
+impl_message_decode!(TakeSnapshotResponseDecoder, Result<()>, |r: _| Ok(r));
+
+/// Encoder for a response of `TakeSnapshot`.
+#[derive(Debug, Default)]
+pub struct TakeSnapshotResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<EmptyMessageEncoder>>>,
+}
+impl_sized_message_encode!(
+    TakeSnapshotResponseEncoder,
+    Result<()>,
+    |item: Self::Item| item
+);
+
+/// Decoder for a response of `Empty`.
+#[derive(Debug, Default)]
+pub struct EmptyResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<EmptyMessageDecoder>>>,
+}
+impl_message_decode!(EmptyResponseDecoder, Result<()>, |r: _| Ok(r));
+
+/// Encoder for a response of `Empty`.
+#[derive(Debug, Default)]
+pub struct EmptyResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<EmptyMessageEncoder>>>,
+}
+impl_sized_message_encode!(EmptyResponseEncoder, Result<()>, |item: Self::Item| item);

--- a/src/protobuf/schema/frugalos.rs
+++ b/src/protobuf/schema/frugalos.rs
@@ -510,7 +510,7 @@ impl_message_encode!(
     }
 );
 
-/// Decoder for a response of `GetObject`.
+/// Decoder for a response of `GetObjectRpc`.
 #[derive(Debug, Default)]
 pub struct GetObjectResponseDecoder {
     inner: ResultDecoder<
@@ -530,7 +530,7 @@ impl_message_decode!(
     |r: Result<Option<(u64, Vec<u8>)>>| Ok(r.map(|v| v.map(|t| (ObjectVersion(t.0), t.1))))
 );
 
-/// Encoder for a response of `GetObject`.
+/// Encoder for a response of `GetObjectRpc`.
 #[derive(Debug, Default)]
 pub struct GetObjectResponseEncoder {
     inner: ResultEncoder<
@@ -550,7 +550,7 @@ impl_sized_message_encode!(
     |item: Self::Item| item.map(|v| v.map(|t| ((t.0).0, t.1)))
 );
 
-/// Decoder for a response of `PutObject`.
+/// Decoder for a response of `PutObjectRpc`.
 #[derive(Debug, Default)]
 pub struct PutObjectResponseDecoder {
     inner: ResultDecoder<
@@ -568,7 +568,7 @@ impl_message_decode!(
     |r: Result<(u64, bool)>| Ok(r.map(|t| (ObjectVersion(t.0), t.1)))
 );
 
-/// Encoder for a response of `PutObject`.
+/// Encoder for a response of `PutObjectRpc`.
 #[derive(Debug, Default)]
 pub struct PutObjectResponseEncoder {
     inner: ResultEncoder<
@@ -586,32 +586,32 @@ impl_sized_message_encode!(
     |item: Self::Item| item.map(|t| ((t.0).0, t.1))
 );
 
-/// Decoder for a response of `CountFragments`.
+/// Decoder for a response of `CountFragmentsRpc`.
 pub type CountFragmentsResponseDecoder = ResultDecoder<OptionDecoder<FragmentsSummaryDecoder>>;
 
-/// Encoder for a response of `CountFragments`.
+/// Encoder for a response of `CountFragmentsRpc`.
 pub type CountFragmentsResponseEncoder = ResultEncoder<OptionEncoder<FragmentsSummaryEncoder>>;
 
-/// Decoder for a response of `Empty`.
+/// Decoder for a response of `DeleteObjectSetFromDeviceRpc`.
 pub type DeleteObjectSetFromDeviceResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
 
-/// Encoder for a response of `Empty`.
+/// Encoder for a response of `DeleteObjectSetFromDeviceRpc`.
 pub type DeleteObjectSetFromDeviceResponseEncoder = ResultEncoder<EmptyMessageEncoder>;
 
-/// Decoder for a response of `Stop`.
+/// Decoder for a response of `StopRpc`.
 pub type StopResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
 
-/// Encoder for a response of `Stop`.
+/// Encoder for a response of `StopRpc`.
 pub type StopResponseEncoder = ResultEncoder<EmptyMessageEncoder>;
 
-/// Decoder for a response of `TakeSnapshot`.
+/// Decoder for a response of `TakeSnapshotRpc`.
 pub type TakeSnapshotResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
 
-/// Encoder for a response of `TakeSnapshot`.
+/// Encoder for a response of `TakeSnapshotRpc`.
 pub type TakeSnapshotResponseEncoder = ResultEncoder<EmptyMessageEncoder>;
 
-/// Decoder for a response of `Empty`.
+/// Decoder for a response of `SetRepairConfigRpc`.
 pub type SetRepairConfigResponseDecoder = ResultDecoder<EmptyMessageDecoder>;
 
-/// Encoder for a response of `Empty`.
+/// Encoder for a response of `SetRepairConfigRpc`.
 pub type SetRepairConfigResponseEncoder = ResultEncoder<EmptyMessageEncoder>;

--- a/src/protobuf/schema/mds.rs
+++ b/src/protobuf/schema/mds.rs
@@ -14,8 +14,7 @@ use protobuf_codec::scalar::{
 };
 use std::time::Duration;
 
-use entity::node::RemoteNodeId;
-use entity::object::{Metadata, ObjectVersion};
+use entity::object::ObjectVersion;
 use protobuf::consistency::{ReadConsistencyDecoder, ReadConsistencyEncoder};
 use protobuf::entity::node::{
     LocalNodeIdDecoder, LocalNodeIdEncoder, RemoteNodeIdDecoder, RemoteNodeIdEncoder,
@@ -360,45 +359,17 @@ impl_sized_message_encode!(
     }
 );
 
-/// Decoder for a response of [GetLeaderRpc].
-#[derive(Debug, Default)]
-pub struct GetLeaderResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<RemoteNodeIdDecoder>>>,
-}
-impl_message_decode!(GetLeaderResponseDecoder, Result<RemoteNodeId>, |t: _| Ok(t));
+/// Decoder for a response of `GetLeaderRpc`.
+pub type GetLeaderResponseDecoder = ResultDecoder<RemoteNodeIdDecoder>;
 
-/// Encoder for a response of [GetLeaderRpc].
-#[derive(Debug, Default)]
-pub struct GetLeaderResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<RemoteNodeIdEncoder>>>,
-}
-impl_message_encode!(
-    GetLeaderResponseEncoder,
-    Result<RemoteNodeId>,
-    |item: Self::Item| item
-);
+/// Encoder for a response of `GetLeaderRpc`.
+pub type GetLeaderResponseEncoder = ResultEncoder<RemoteNodeIdEncoder>;
 
 /// Decoder for a response of `Option<Metadata>`.
-#[derive(Debug, Default)]
-pub struct MaybeMetadataResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<MetadataDecoder>>>>,
-}
-impl_message_decode!(
-    MaybeMetadataResponseDecoder,
-    Result<Option<Metadata>>,
-    |t: _| Ok(t)
-);
+pub type MaybeMetadataResponseDecoder = ResultDecoder<OptionDecoder<MetadataDecoder>>;
 
 /// Encoder for a response of `Option<Metadata>`.
-#[derive(Debug, Default)]
-pub struct MaybeMetadataResponseEncoder {
-    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<MetadataEncoder>>>>,
-}
-impl_message_encode!(
-    MaybeMetadataResponseEncoder,
-    Result<Option<Metadata>>,
-    |item: Self::Item| item
-);
+pub type MaybeMetadataResponseEncoder = ResultEncoder<OptionEncoder<MetadataEncoder>>;
 
 /// Decoder for a response of `PutObject`.
 #[derive(Debug, Default)]
@@ -447,23 +418,9 @@ impl_message_encode!(
 );
 
 /// Decoder for a response of `ObjectCount`.
-#[derive(Debug, Default)]
-pub struct ObjectCountResponseDecoder {
-    inner: MessageDecoder<
-        MessageFieldDecoder<F1, ResultDecoder<MessageDecoder<FieldDecoder<F1, Uint64Decoder>>>>,
-    >,
-}
-impl_message_decode!(ObjectCountResponseDecoder, Result<u64>, |t: _| Ok(t));
+pub type ObjectCountResponseDecoder =
+    ResultDecoder<MessageDecoder<FieldDecoder<F1, Uint64Decoder>>>;
 
 /// Encoder for a response of `ObjectCount`.
-#[derive(Debug, Default)]
-pub struct ObjectCountResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<F1, ResultEncoder<MessageEncoder<FieldEncoder<F1, Uint64Encoder>>>>,
-    >,
-}
-impl_message_encode!(
-    ObjectCountResponseEncoder,
-    Result<u64>,
-    |item: Self::Item| item
-);
+pub type ObjectCountResponseEncoder =
+    ResultEncoder<MessageEncoder<FieldEncoder<F1, Uint64Encoder>>>;

--- a/src/protobuf/schema/mds.rs
+++ b/src/protobuf/schema/mds.rs
@@ -1,0 +1,467 @@
+//! test
+
+use bytecodec::combinator::PreEncode;
+use protobuf_codec::field::num::{F1, F2, F3, F4, F5};
+use protobuf_codec::field::{
+    FieldDecoder, FieldEncoder, Fields, MaybeDefault, MessageFieldDecoder, MessageFieldEncoder,
+    Optional,
+};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+use protobuf_codec::scalar::{
+    BytesDecoder, BytesEncoder, StringDecoder, StringEncoder, Uint64Decoder, Uint64Encoder,
+};
+use std::time::Duration;
+
+use entity::node::RemoteNodeId;
+use entity::object::{Metadata, ObjectVersion};
+use protobuf::consistency::{ReadConsistencyDecoder, ReadConsistencyEncoder};
+use protobuf::entity::node::{
+    LocalNodeIdDecoder, LocalNodeIdEncoder, RemoteNodeIdDecoder, RemoteNodeIdEncoder,
+};
+use protobuf::entity::object::{
+    MetadataDecoder, MetadataEncoder, ObjectPrefixDecoder, ObjectPrefixEncoder, ObjectRangeDecoder,
+    ObjectRangeEncoder, ObjectVersionDecoder, ObjectVersionEncoder,
+};
+use protobuf::expect::{ExpectDecoder, ExpectEncoder};
+use protobuf::{OptionDecoder, OptionEncoder, ResultDecoder, ResultEncoder};
+use schema::mds::{
+    GetLatestVersionRequest, GetLeaderRequest, ListObjectsRequest, ObjectCountRequest,
+    ObjectRequest, PrefixRequest, PutObjectRequest, RangeRequest, RecommendToLeaderRequest,
+    VersionRequest,
+};
+use Result;
+
+/// Decoder for `GetLeaderRequest`.
+#[derive(Debug, Default)]
+pub struct GetLeaderRequestDecoder {
+    inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>>,
+}
+impl_message_decode!(GetLeaderRequestDecoder, GetLeaderRequest, |node_id: _| {
+    Ok(GetLeaderRequest { node_id })
+});
+
+/// Encoder for `GetLeaderRequest`.
+#[derive(Debug, Default)]
+pub struct GetLeaderRequestEncoder {
+    inner: MessageEncoder<FieldEncoder<F1, LocalNodeIdEncoder>>,
+}
+impl_sized_message_encode!(
+    GetLeaderRequestEncoder,
+    GetLeaderRequest,
+    |item: Self::Item| item.node_id
+);
+
+/// Decoder for `RecommendToLeaderRequest`.
+#[derive(Debug, Default)]
+pub struct RecommendToLeaderRequestDecoder {
+    inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>>,
+}
+impl_message_decode!(
+    RecommendToLeaderRequestDecoder,
+    RecommendToLeaderRequest,
+    |node_id: _| { Ok(RecommendToLeaderRequest { node_id }) }
+);
+
+/// Encoder for `RecommendToLeaderRequest`.
+#[derive(Debug, Default)]
+pub struct RecommendToLeaderRequestEncoder {
+    inner: MessageEncoder<FieldEncoder<F1, LocalNodeIdEncoder>>,
+}
+impl_sized_message_encode!(
+    RecommendToLeaderRequestEncoder,
+    RecommendToLeaderRequest,
+    |item: Self::Item| item.node_id
+);
+
+/// Decoder for `GetLatestVersionRequest`.
+#[derive(Debug, Default)]
+pub struct GetLatestVersionRequestDecoder {
+    inner: MessageDecoder<MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>>,
+}
+impl_message_decode!(
+    GetLatestVersionRequestDecoder,
+    GetLatestVersionRequest,
+    |node_id: _| { Ok(GetLatestVersionRequest { node_id }) }
+);
+
+/// Encoder for `GetLatestVersionRequest`.
+#[derive(Debug, Default)]
+pub struct GetLatestVersionRequestEncoder {
+    inner: MessageEncoder<FieldEncoder<F1, LocalNodeIdEncoder>>,
+}
+impl_sized_message_encode!(
+    GetLatestVersionRequestEncoder,
+    GetLatestVersionRequest,
+    |item: Self::Item| item.node_id
+);
+
+/// Decoder for `ObjectRequest`.
+#[derive(Debug, Default)]
+pub struct ObjectRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, StringDecoder>>,
+            MessageFieldDecoder<F3, ExpectDecoder>,
+            Optional<MessageFieldDecoder<F4, ReadConsistencyDecoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(ObjectRequestDecoder, ObjectRequest, |t: (
+    String,
+    String,
+    _,
+    _,
+)| {
+    Ok(ObjectRequest {
+        node_id: t.0.clone(),
+        object_id: t.1.clone(),
+        expect: t.2,
+        consistency: t.3,
+    })
+});
+
+/// Encoder for `ObjectRequest`.
+#[derive(Debug, Default)]
+pub struct ObjectRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, LocalNodeIdEncoder>,
+            FieldEncoder<F2, StringEncoder>,
+            MessageFieldEncoder<F3, PreEncode<ExpectEncoder>>,
+            Optional<MessageFieldEncoder<F4, ReadConsistencyEncoder>>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(ObjectRequestEncoder, ObjectRequest, |item: Self::Item| {
+    (item.node_id, item.object_id, item.expect, item.consistency)
+});
+
+/// Decoder for `ListObjectsRequest`.
+#[derive(Debug, Default)]
+pub struct ListObjectsRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>,
+            MessageFieldDecoder<F2, ReadConsistencyDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(ListObjectsRequestDecoder, ListObjectsRequest, |t: (
+    String,
+    _,
+)| {
+    Ok(ListObjectsRequest {
+        node_id: t.0.clone(),
+        consistency: t.1,
+    })
+});
+
+/// Encoder for `ListObjectsRequest`.
+#[derive(Debug, Default)]
+pub struct ListObjectsRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, LocalNodeIdEncoder>,
+            MessageFieldEncoder<F2, ReadConsistencyEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    ListObjectsRequestEncoder,
+    ListObjectsRequest,
+    |item: Self::Item| { (item.node_id, item.consistency,) }
+);
+
+/// Decoder for `ObjectCountRequest`.
+#[derive(Debug, Default)]
+pub struct ObjectCountRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>,
+            MessageFieldDecoder<F2, ReadConsistencyDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(ObjectCountRequestDecoder, ObjectCountRequest, |t: (
+    String,
+    _,
+)| {
+    Ok(ObjectCountRequest {
+        node_id: t.0.clone(),
+        consistency: t.1,
+    })
+});
+
+/// Encoder for `ObjectCountRequest`.
+#[derive(Debug, Default)]
+pub struct ObjectCountRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, LocalNodeIdEncoder>,
+            MessageFieldEncoder<F2, ReadConsistencyEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    ObjectCountRequestEncoder,
+    ObjectCountRequest,
+    |item: Self::Item| { (item.node_id, item.consistency,) }
+);
+
+/// Decoder for `VersionRequest`.
+#[derive(Debug, Default)]
+pub struct VersionRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, ObjectVersionDecoder>>,
+        )>,
+    >,
+}
+impl_message_decode!(VersionRequestDecoder, VersionRequest, |t: (String, _,)| {
+    Ok(VersionRequest {
+        node_id: t.0.clone(),
+        object_version: ObjectVersion(t.1),
+    })
+});
+
+/// Encoder for `VersionRequest`.
+#[derive(Debug, Default)]
+pub struct VersionRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, LocalNodeIdEncoder>,
+            FieldEncoder<F2, ObjectVersionEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(VersionRequestEncoder, VersionRequest, |item: Self::Item| {
+    (item.node_id, item.object_version.0)
+});
+
+/// Decoder for `RangeRequest`.
+#[derive(Debug, Default)]
+pub struct RangeRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>,
+            MessageFieldDecoder<F2, ObjectRangeDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(RangeRequestDecoder, RangeRequest, |t: (String, _,)| {
+    Ok(RangeRequest {
+        node_id: t.0.clone(),
+        targets: t.1,
+    })
+});
+
+/// Encoder for `RangeRequest`.
+#[derive(Debug, Default)]
+pub struct RangeRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, LocalNodeIdEncoder>,
+            MessageFieldEncoder<F2, ObjectRangeEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(RangeRequestEncoder, RangeRequest, |item: Self::Item| {
+    (item.node_id, item.targets)
+});
+
+/// Decoder for `PrefixRequest`.
+#[derive(Debug, Default)]
+pub struct PrefixRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>,
+            MessageFieldDecoder<F2, ObjectPrefixDecoder>,
+        )>,
+    >,
+}
+impl_message_decode!(PrefixRequestDecoder, PrefixRequest, |t: (String, _,)| {
+    Ok(PrefixRequest {
+        node_id: t.0.clone(),
+        prefix: t.1,
+    })
+});
+
+/// Encoder for `PrefixRequest`.
+#[derive(Debug, Default)]
+pub struct PrefixRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, LocalNodeIdEncoder>,
+            MessageFieldEncoder<F2, ObjectPrefixEncoder>,
+        )>,
+    >,
+}
+impl_sized_message_encode!(PrefixRequestEncoder, PrefixRequest, |item: Self::Item| {
+    (item.node_id, item.prefix)
+});
+
+/// Decoder for `PutObjectRequest`.
+#[derive(Debug, Default)]
+pub struct PutObjectRequestDecoder {
+    inner: MessageDecoder<
+        Fields<(
+            MaybeDefault<FieldDecoder<F1, LocalNodeIdDecoder>>,
+            MaybeDefault<FieldDecoder<F2, StringDecoder>>,
+            MaybeDefault<FieldDecoder<F3, BytesDecoder>>,
+            MessageFieldDecoder<F4, ExpectDecoder>,
+            FieldDecoder<F5, Uint64Decoder>, // TODO
+        )>,
+    >,
+}
+impl_message_decode!(PutObjectRequestDecoder, PutObjectRequest, |t: (
+    String,
+    String,
+    _,
+    _,
+    _,
+)| {
+    Ok(PutObjectRequest {
+        node_id: t.0.clone(),
+        object_id: t.1.clone(),
+        metadata: t.2,
+        expect: t.3,
+        put_content_timeout: Duration::from_secs(t.4),
+    })
+});
+
+/// Encoder for `PutObjectRequest`.
+#[derive(Debug, Default)]
+pub struct PutObjectRequestEncoder {
+    inner: MessageEncoder<
+        Fields<(
+            FieldEncoder<F1, LocalNodeIdEncoder>,
+            FieldEncoder<F2, StringEncoder>,
+            FieldEncoder<F3, BytesEncoder>,
+            MessageFieldEncoder<F4, ExpectEncoder>,
+            FieldEncoder<F5, Uint64Encoder>, // TODO
+        )>,
+    >,
+}
+impl_sized_message_encode!(
+    PutObjectRequestEncoder,
+    PutObjectRequest,
+    |item: Self::Item| {
+        (
+            item.node_id,
+            item.object_id,
+            item.metadata,
+            item.expect,
+            item.put_content_timeout.as_secs(),
+        )
+    }
+);
+
+/// Decoder for a response of [GetLeaderRpc].
+#[derive(Debug, Default)]
+pub struct GetLeaderResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<RemoteNodeIdDecoder>>>,
+}
+impl_message_decode!(GetLeaderResponseDecoder, Result<RemoteNodeId>, |t: _| Ok(t));
+
+/// Encoder for a response of [GetLeaderRpc].
+#[derive(Debug, Default)]
+pub struct GetLeaderResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<RemoteNodeIdEncoder>>>,
+}
+impl_message_encode!(
+    GetLeaderResponseEncoder,
+    Result<RemoteNodeId>,
+    |item: Self::Item| item
+);
+
+/// Decoder for a response of `Option<Metadata>`.
+#[derive(Debug, Default)]
+pub struct MaybeMetadataResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<MetadataDecoder>>>>,
+}
+impl_message_decode!(
+    MaybeMetadataResponseDecoder,
+    Result<Option<Metadata>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for a response of `Option<Metadata>`.
+#[derive(Debug, Default)]
+pub struct MaybeMetadataResponseEncoder {
+    inner: MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<MetadataEncoder>>>>,
+}
+impl_message_encode!(
+    MaybeMetadataResponseEncoder,
+    Result<Option<Metadata>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for a response of `PutObject`.
+#[derive(Debug, Default)]
+pub struct PutObjectResponseDecoder {
+    inner: MessageDecoder<
+        MessageFieldDecoder<
+            F1,
+            ResultDecoder<
+                MessageDecoder<
+                    Fields<(
+                        MaybeDefault<FieldDecoder<F1, ObjectVersionDecoder>>,
+                        Optional<FieldDecoder<F2, ObjectVersionDecoder>>,
+                    )>,
+                >,
+            >,
+        >,
+    >,
+}
+impl_message_decode!(
+    PutObjectResponseDecoder,
+    Result<(ObjectVersion, Option<ObjectVersion>)>,
+    |r: Result<(u64, Option<u64>)>| Ok(r.map(|t| (ObjectVersion(t.0), t.1.map(ObjectVersion))))
+);
+
+/// Encoder for a response of `PutObject`.
+#[derive(Debug, Default)]
+pub struct PutObjectResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<
+            F1,
+            ResultEncoder<
+                MessageEncoder<
+                    Fields<(
+                        FieldEncoder<F1, ObjectVersionEncoder>,
+                        Optional<FieldEncoder<F2, ObjectVersionEncoder>>,
+                    )>,
+                >,
+            >,
+        >,
+    >,
+}
+impl_message_encode!(
+    PutObjectResponseEncoder,
+    Result<(ObjectVersion, Option<ObjectVersion>)>,
+    |item: Self::Item| item.map(|t| ((t.0).0, t.1.map(|v| v.0)))
+);
+
+/// Decoder for a response of `ObjectCount`.
+#[derive(Debug, Default)]
+pub struct ObjectCountResponseDecoder {
+    inner: MessageDecoder<
+        MessageFieldDecoder<F1, ResultDecoder<MessageDecoder<FieldDecoder<F1, Uint64Decoder>>>>,
+    >,
+}
+impl_message_decode!(ObjectCountResponseDecoder, Result<u64>, |t: _| Ok(t));
+
+/// Encoder for a response of `ObjectCount`.
+#[derive(Debug, Default)]
+pub struct ObjectCountResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<F1, ResultEncoder<MessageEncoder<FieldEncoder<F1, Uint64Encoder>>>>,
+    >,
+}
+impl_message_encode!(
+    ObjectCountResponseEncoder,
+    Result<u64>,
+    |item: Self::Item| item
+);

--- a/src/protobuf/schema/mds.rs
+++ b/src/protobuf/schema/mds.rs
@@ -371,7 +371,7 @@ pub type MaybeMetadataResponseDecoder = ResultDecoder<OptionDecoder<MetadataDeco
 /// Encoder for a response of `Option<Metadata>`.
 pub type MaybeMetadataResponseEncoder = ResultEncoder<OptionEncoder<MetadataEncoder>>;
 
-/// Decoder for a response of `PutObject`.
+/// Decoder for a response of `PutObjectRpc`.
 #[derive(Debug, Default)]
 pub struct PutObjectResponseDecoder {
     inner: MessageDecoder<
@@ -394,7 +394,7 @@ impl_message_decode!(
     |r: Result<(u64, Option<u64>)>| Ok(r.map(|t| (ObjectVersion(t.0), t.1.map(ObjectVersion))))
 );
 
-/// Encoder for a response of `PutObject`.
+/// Encoder for a response of `PutObjectRpc`.
 #[derive(Debug, Default)]
 pub struct PutObjectResponseEncoder {
     inner: MessageEncoder<
@@ -417,10 +417,10 @@ impl_message_encode!(
     |item: Self::Item| item.map(|t| ((t.0).0, t.1.map(|v| v.0)))
 );
 
-/// Decoder for a response of `ObjectCount`.
+/// Decoder for a response of `ObjectCountRpc`.
 pub type ObjectCountResponseDecoder =
     ResultDecoder<MessageDecoder<FieldDecoder<F1, Uint64Decoder>>>;
 
-/// Encoder for a response of `ObjectCount`.
+/// Encoder for a response of `ObjectCountRpc`.
 pub type ObjectCountResponseEncoder =
     ResultEncoder<MessageEncoder<FieldEncoder<F1, Uint64Encoder>>>;

--- a/src/protobuf/schema/mds.rs
+++ b/src/protobuf/schema/mds.rs
@@ -312,7 +312,7 @@ pub struct PutObjectRequestDecoder {
             MaybeDefault<FieldDecoder<F2, StringDecoder>>,
             MaybeDefault<FieldDecoder<F3, BytesDecoder>>,
             MessageFieldDecoder<F4, ExpectDecoder>,
-            FieldDecoder<F5, Uint64Decoder>, // TODO
+            FieldDecoder<F5, Uint64Decoder>,
         )>,
     >,
 }
@@ -341,7 +341,7 @@ pub struct PutObjectRequestEncoder {
             FieldEncoder<F2, StringEncoder>,
             FieldEncoder<F3, BytesEncoder>,
             MessageFieldEncoder<F4, ExpectEncoder>,
-            FieldEncoder<F5, Uint64Encoder>, // TODO
+            FieldEncoder<F5, Uint64Encoder>,
         )>,
     >,
 }

--- a/src/protobuf/schema/mds.rs
+++ b/src/protobuf/schema/mds.rs
@@ -1,4 +1,6 @@
-//! test
+//! Decoders and encoders for [`libmds::schema::mds`](../../schema/mds/index.html).
+//!
+//! `package libmds.protobuf.schema.mds`.
 
 use bytecodec::combinator::PreEncode;
 use protobuf_codec::field::num::{F1, F2, F3, F4, F5};

--- a/src/protobuf/schema/mod.rs
+++ b/src/protobuf/schema/mod.rs
@@ -1,4 +1,6 @@
-//! Encoders and decoders of Protocol Buffers.
+//! Decoders and encoders for [`libfrugalos::schema`](../../schema/index.html).
+//!
+//! `package libfrugalos.protobuf.schema`.
 
 pub mod config;
 pub mod frugalos;

--- a/src/protobuf/schema/mod.rs
+++ b/src/protobuf/schema/mod.rs
@@ -1,0 +1,6 @@
+//! Encoders and decoders of Protocol Buffers.
+
+pub mod config;
+pub mod frugalos;
+pub mod mds;
+pub mod object;

--- a/src/protobuf/schema/object.rs
+++ b/src/protobuf/schema/object.rs
@@ -1,4 +1,4 @@
-//! object
+//! Common decoders and encoders for schemas.
 
 use bytecodec::combinator::PreEncode;
 use protobuf_codec::field::num::F1;

--- a/src/protobuf/schema/object.rs
+++ b/src/protobuf/schema/object.rs
@@ -1,11 +1,10 @@
 //! Common decoders and encoders for schemas.
 
-use bytecodec::combinator::PreEncode;
 use protobuf_codec::field::num::F1;
-use protobuf_codec::field::{FieldDecoder, FieldEncoder, MessageFieldDecoder, MessageFieldEncoder};
+use protobuf_codec::field::{FieldDecoder, FieldEncoder};
 use protobuf_codec::message::{MessageDecoder, MessageEncoder};
 
-use entity::object::{DeleteObjectsByPrefixSummary, ObjectSummary, ObjectVersion};
+use entity::object::ObjectVersion;
 use protobuf::entity::object::{
     DeleteObjectsByPrefixSummaryDecoder, DeleteObjectsByPrefixSummaryEncoder, ObjectSummaryDecoder,
     ObjectSummaryEncoder, ObjectVersionDecoder, ObjectVersionEncoder,
@@ -16,38 +15,29 @@ use protobuf::{
 use Result;
 
 /// Decoder for a response of `DeleteObjectsByPrefixSummary`.
-#[derive(Debug, Default)]
-pub struct DeleteObjectsByPrefixSummaryResponseDecoder {
-    inner:
-        MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<DeleteObjectsByPrefixSummaryDecoder>>>,
-}
-impl_message_decode!(
-    DeleteObjectsByPrefixSummaryResponseDecoder,
-    Result<DeleteObjectsByPrefixSummary>,
-    |t: _| Ok(t)
-);
+pub type DeleteObjectsByPrefixSummaryResponseDecoder =
+    ResultDecoder<DeleteObjectsByPrefixSummaryDecoder>;
 
 /// Encoder for a response of `DeleteObjectsByPrefixSummary`.
-#[derive(Debug, Default)]
-pub struct DeleteObjectsByPrefixSummaryResponseEncoder {
-    inner:
-        MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<DeleteObjectsByPrefixSummaryEncoder>>>,
-}
-impl_message_encode!(
-    DeleteObjectsByPrefixSummaryResponseEncoder,
-    Result<DeleteObjectsByPrefixSummary>,
-    |item: Self::Item| item
-);
+pub type DeleteObjectsByPrefixSummaryResponseEncoder =
+    ResultEncoder<DeleteObjectsByPrefixSummaryEncoder>;
+
+/// Decoder for a response of `Option<ObjectSummary>`.
+pub type MaybeObjectSummaryResponseDecoder = ResultDecoder<OptionDecoder<ObjectSummaryDecoder>>;
+
+/// Encoder for a response of `Option<ObjectSummary>`.
+pub type MaybeObjectSummaryResponseEncoder = ResultEncoder<OptionEncoder<ObjectSummaryEncoder>>;
+
+/// Decoder for a response of `Vec<ObjectSummary>`.
+pub type ObjectSummarySequenceResponseDecoder = ResultDecoder<VecDecoder<ObjectSummaryDecoder>>;
+
+/// Encoder for a response of `Vec<ObjectSummary>`.
+pub type ObjectSummarySequenceResponseEncoder = ResultEncoder<VecEncoder<ObjectSummaryEncoder>>;
 
 /// Decoder for a response of `Option<ObjectVersion>`.
 #[derive(Debug, Default)]
 pub struct MaybeObjectVersionResponseDecoder {
-    inner: MessageDecoder<
-        MessageFieldDecoder<
-            F1,
-            ResultDecoder<OptionDecoder<MessageDecoder<FieldDecoder<F1, ObjectVersionDecoder>>>>,
-        >,
-    >,
+    inner: ResultDecoder<OptionDecoder<MessageDecoder<FieldDecoder<F1, ObjectVersionDecoder>>>>,
 }
 impl_message_decode!(
     MaybeObjectVersionResponseDecoder,
@@ -58,63 +48,10 @@ impl_message_decode!(
 /// Encoder for a response of `Option<ObjectVersion>`.
 #[derive(Debug, Default)]
 pub struct MaybeObjectVersionResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<
-            F1,
-            ResultEncoder<OptionEncoder<MessageEncoder<FieldEncoder<F1, ObjectVersionEncoder>>>>,
-        >,
-    >,
+    inner: ResultEncoder<OptionEncoder<MessageEncoder<FieldEncoder<F1, ObjectVersionEncoder>>>>,
 }
 impl_message_encode!(
     MaybeObjectVersionResponseEncoder,
     Result<Option<ObjectVersion>>,
     |item: Self::Item| item.map(|x| x.map(|v| v.0))
-);
-
-/// Decoder for a response of `Option<ObjectSummary>`.
-#[derive(Debug, Default)]
-pub struct MaybeObjectSummaryResponseDecoder {
-    inner:
-        MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<ObjectSummaryDecoder>>>>,
-}
-impl_message_decode!(
-    MaybeObjectSummaryResponseDecoder,
-    Result<Option<ObjectSummary>>,
-    |t: _| Ok(t)
-);
-
-/// Encoder for a response of `Option<ObjectSummary>`.
-#[derive(Debug, Default)]
-pub struct MaybeObjectSummaryResponseEncoder {
-    inner:
-        MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<ObjectSummaryEncoder>>>>,
-}
-impl_message_encode!(
-    MaybeObjectSummaryResponseEncoder,
-    Result<Option<ObjectSummary>>,
-    |item: Self::Item| item
-);
-
-/// Decoder for a response of `Vec<ObjectSummary>`.
-#[derive(Debug, Default)]
-pub struct ObjectSummarySequenceResponseDecoder {
-    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<ObjectSummaryDecoder>>>>,
-}
-impl_message_decode!(
-    ObjectSummarySequenceResponseDecoder,
-    Result<Vec<ObjectSummary>>,
-    |t: _| Ok(t)
-);
-
-/// Encoder for a response of `Vec<ObjectSummary>`.
-#[derive(Debug, Default)]
-pub struct ObjectSummarySequenceResponseEncoder {
-    inner: MessageEncoder<
-        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<ObjectSummaryEncoder>>>>,
-    >,
-}
-impl_message_encode!(
-    ObjectSummarySequenceResponseEncoder,
-    Result<Vec<ObjectSummary>>,
-    |item: Self::Item| item
 );

--- a/src/protobuf/schema/object.rs
+++ b/src/protobuf/schema/object.rs
@@ -1,0 +1,120 @@
+//! object
+
+use bytecodec::combinator::PreEncode;
+use protobuf_codec::field::num::F1;
+use protobuf_codec::field::{FieldDecoder, FieldEncoder, MessageFieldDecoder, MessageFieldEncoder};
+use protobuf_codec::message::{MessageDecoder, MessageEncoder};
+
+use entity::object::{DeleteObjectsByPrefixSummary, ObjectSummary, ObjectVersion};
+use protobuf::entity::object::{
+    DeleteObjectsByPrefixSummaryDecoder, DeleteObjectsByPrefixSummaryEncoder, ObjectSummaryDecoder,
+    ObjectSummaryEncoder, ObjectVersionDecoder, ObjectVersionEncoder,
+};
+use protobuf::{
+    OptionDecoder, OptionEncoder, ResultDecoder, ResultEncoder, VecDecoder, VecEncoder,
+};
+use Result;
+
+/// Decoder for a response of `DeleteObjectsByPrefixSummary`.
+#[derive(Debug, Default)]
+pub struct DeleteObjectsByPrefixSummaryResponseDecoder {
+    inner:
+        MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<DeleteObjectsByPrefixSummaryDecoder>>>,
+}
+impl_message_decode!(
+    DeleteObjectsByPrefixSummaryResponseDecoder,
+    Result<DeleteObjectsByPrefixSummary>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for a response of `DeleteObjectsByPrefixSummary`.
+#[derive(Debug, Default)]
+pub struct DeleteObjectsByPrefixSummaryResponseEncoder {
+    inner:
+        MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<DeleteObjectsByPrefixSummaryEncoder>>>,
+}
+impl_message_encode!(
+    DeleteObjectsByPrefixSummaryResponseEncoder,
+    Result<DeleteObjectsByPrefixSummary>,
+    |item: Self::Item| item
+);
+
+/// Decoder for a response of `Option<ObjectVersion>`.
+#[derive(Debug, Default)]
+pub struct MaybeObjectVersionResponseDecoder {
+    inner: MessageDecoder<
+        MessageFieldDecoder<
+            F1,
+            ResultDecoder<OptionDecoder<MessageDecoder<FieldDecoder<F1, ObjectVersionDecoder>>>>,
+        >,
+    >,
+}
+impl_message_decode!(
+    MaybeObjectVersionResponseDecoder,
+    Result<Option<ObjectVersion>>,
+    |t: Result<Option<u64>>| Ok(t.map(|x| x.map(ObjectVersion)))
+);
+
+/// Encoder for a response of `Option<ObjectVersion>`.
+#[derive(Debug, Default)]
+pub struct MaybeObjectVersionResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<
+            F1,
+            ResultEncoder<OptionEncoder<MessageEncoder<FieldEncoder<F1, ObjectVersionEncoder>>>>,
+        >,
+    >,
+}
+impl_message_encode!(
+    MaybeObjectVersionResponseEncoder,
+    Result<Option<ObjectVersion>>,
+    |item: Self::Item| item.map(|x| x.map(|v| v.0))
+);
+
+/// Decoder for a response of `Option<ObjectSummary>`.
+#[derive(Debug, Default)]
+pub struct MaybeObjectSummaryResponseDecoder {
+    inner:
+        MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<OptionDecoder<ObjectSummaryDecoder>>>>,
+}
+impl_message_decode!(
+    MaybeObjectSummaryResponseDecoder,
+    Result<Option<ObjectSummary>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for a response of `Option<ObjectSummary>`.
+#[derive(Debug, Default)]
+pub struct MaybeObjectSummaryResponseEncoder {
+    inner:
+        MessageEncoder<MessageFieldEncoder<F1, ResultEncoder<OptionEncoder<ObjectSummaryEncoder>>>>,
+}
+impl_message_encode!(
+    MaybeObjectSummaryResponseEncoder,
+    Result<Option<ObjectSummary>>,
+    |item: Self::Item| item
+);
+
+/// Decoder for a response of `Vec<ObjectSummary>`.
+#[derive(Debug, Default)]
+pub struct ObjectSummarySequenceResponseDecoder {
+    inner: MessageDecoder<MessageFieldDecoder<F1, ResultDecoder<VecDecoder<ObjectSummaryDecoder>>>>,
+}
+impl_message_decode!(
+    ObjectSummarySequenceResponseDecoder,
+    Result<Vec<ObjectSummary>>,
+    |t: _| Ok(t)
+);
+
+/// Encoder for a response of `Vec<ObjectSummary>`.
+#[derive(Debug, Default)]
+pub struct ObjectSummarySequenceResponseEncoder {
+    inner: MessageEncoder<
+        MessageFieldEncoder<F1, PreEncode<ResultEncoder<VecEncoder<ObjectSummaryEncoder>>>>,
+    >,
+}
+impl_message_encode!(
+    ObjectSummarySequenceResponseEncoder,
+    Result<Vec<ObjectSummary>>,
+    |item: Self::Item| item
+);

--- a/src/schema/config.rs
+++ b/src/schema/config.rs
@@ -1,11 +1,25 @@
 //! 構成管理系RPCのスキーマ定義。
-use bytecodec::bincode_codec::{BincodeDecoder, BincodeEncoder};
 use fibers_rpc::{Call, ProcedureId};
+use protobuf_codec::wellknown::google::protobuf::{EmptyMessageDecoder, EmptyMessageEncoder};
 use std::net::SocketAddr;
 
 use entity::bucket::{Bucket, BucketId, BucketSummary};
 use entity::device::{Device, DeviceId, DeviceSummary};
 use entity::server::{Server, ServerId, ServerSummary};
+use protobuf::entity::bucket::{BucketDecoder, BucketEncoder, BucketIdDecoder, BucketIdEncoder};
+use protobuf::entity::device::{DeviceDecoder, DeviceEncoder, DeviceIdDecoder, DeviceIdEncoder};
+use protobuf::entity::server::{ServerDecoder, ServerEncoder, ServerIdDecoder, ServerIdEncoder};
+use protobuf::schema::config::{
+    DeleteBucketResponseDecoder, DeleteBucketResponseEncoder, DeleteDeviceResponseDecoder,
+    DeleteDeviceResponseEncoder, DeleteServerResponseDecoder, DeleteServerResponseEncoder,
+    GetBucketResponseDecoder, GetBucketResponseEncoder, GetDeviceResponseDecoder,
+    GetDeviceResponseEncoder, GetLeaderResponseDecoder, GetLeaderResponseEncoder,
+    GetServerResponseDecoder, GetServerResponseEncoder, ListBucketsResponseDecoder,
+    ListBucketsResponseEncoder, ListDevicesResponseDecoder, ListDevicesResponseEncoder,
+    ListServersResponseDecoder, ListServersResponseEncoder, PutBucketResponseDecoder,
+    PutBucketResponseEncoder, PutDeviceResponseDecoder, PutDeviceResponseEncoder,
+    PutServerResponseDecoder, PutServerResponseEncoder,
+};
 use Result;
 
 /// サーバ一覧取得RPC。
@@ -16,12 +30,12 @@ impl Call for ListServersRpc {
     const NAME: &'static str = "frugalos.config.server.list";
 
     type Req = ();
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = EmptyMessageDecoder;
+    type ReqEncoder = EmptyMessageEncoder;
 
     type Res = Result<Vec<ServerSummary>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = ListServersResponseDecoder;
+    type ResEncoder = ListServersResponseEncoder;
 }
 
 /// サーバ情報取得RPC。
@@ -32,12 +46,12 @@ impl Call for GetServerRpc {
     const NAME: &'static str = "frugalos.config.server.get";
 
     type Req = ServerId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ServerIdDecoder;
+    type ReqEncoder = ServerIdEncoder;
 
     type Res = Result<Option<Server>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = GetServerResponseDecoder;
+    type ResEncoder = GetServerResponseEncoder;
 }
 
 /// サーバ登録RPC。
@@ -48,12 +62,12 @@ impl Call for PutServerRpc {
     const NAME: &'static str = "frugalos.config.server.put";
 
     type Req = Server;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ServerDecoder;
+    type ReqEncoder = ServerEncoder;
 
     type Res = Result<Server>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = PutServerResponseDecoder;
+    type ResEncoder = PutServerResponseEncoder;
 }
 
 /// サーバ削除RPC。
@@ -64,12 +78,12 @@ impl Call for DeleteServerRpc {
     const NAME: &'static str = "frugalos.config.server.delete";
 
     type Req = ServerId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ServerIdDecoder;
+    type ReqEncoder = ServerIdEncoder;
 
     type Res = Result<Option<Server>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = DeleteServerResponseDecoder;
+    type ResEncoder = DeleteServerResponseEncoder;
 }
 
 /// デバイス一覧取得RPC。
@@ -80,12 +94,12 @@ impl Call for ListDevicesRpc {
     const NAME: &'static str = "frugalos.config.device.list";
 
     type Req = ();
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = EmptyMessageDecoder;
+    type ReqEncoder = EmptyMessageEncoder;
 
     type Res = Result<Vec<DeviceSummary>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = ListDevicesResponseDecoder;
+    type ResEncoder = ListDevicesResponseEncoder;
 }
 
 /// デバイス情報取得RPC。
@@ -96,12 +110,12 @@ impl Call for GetDeviceRpc {
     const NAME: &'static str = "frugalos.config.device.get";
 
     type Req = DeviceId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = DeviceIdDecoder;
+    type ReqEncoder = DeviceIdEncoder;
 
     type Res = Result<Option<Device>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = GetDeviceResponseDecoder;
+    type ResEncoder = GetDeviceResponseEncoder;
 }
 
 /// デバイス登録RPC。
@@ -112,12 +126,12 @@ impl Call for PutDeviceRpc {
     const NAME: &'static str = "frugalos.config.device.put";
 
     type Req = Device;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = DeviceDecoder;
+    type ReqEncoder = DeviceEncoder;
 
     type Res = Result<Device>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = PutDeviceResponseDecoder;
+    type ResEncoder = PutDeviceResponseEncoder;
 }
 
 /// デバイス削除RPC。
@@ -128,12 +142,12 @@ impl Call for DeleteDeviceRpc {
     const NAME: &'static str = "frugalos.config.device.delete";
 
     type Req = DeviceId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = DeviceIdDecoder;
+    type ReqEncoder = DeviceIdEncoder;
 
     type Res = Result<Option<Device>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = DeleteDeviceResponseDecoder;
+    type ResEncoder = DeleteDeviceResponseEncoder;
 }
 
 /// バケツ一覧取得RPC。
@@ -144,12 +158,12 @@ impl Call for ListBucketsRpc {
     const NAME: &'static str = "frugalos.config.bucket.list";
 
     type Req = ();
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = EmptyMessageDecoder;
+    type ReqEncoder = EmptyMessageEncoder;
 
     type Res = Result<Vec<BucketSummary>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = ListBucketsResponseDecoder;
+    type ResEncoder = ListBucketsResponseEncoder;
 }
 
 /// バケツ情報取得RPC。
@@ -160,12 +174,12 @@ impl Call for GetBucketRpc {
     const NAME: &'static str = "frugalos.config.bucket.get";
 
     type Req = BucketId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = BucketIdDecoder;
+    type ReqEncoder = BucketIdEncoder;
 
     type Res = Result<Option<Bucket>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = GetBucketResponseDecoder;
+    type ResEncoder = GetBucketResponseEncoder;
 }
 
 /// バケツ登録RPC。
@@ -176,12 +190,12 @@ impl Call for PutBucketRpc {
     const NAME: &'static str = "frugalos.config.bucket.put";
 
     type Req = Bucket;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = BucketDecoder;
+    type ReqEncoder = BucketEncoder;
 
     type Res = Result<Bucket>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = PutBucketResponseDecoder;
+    type ResEncoder = PutBucketResponseEncoder;
 }
 
 /// バケツ削除RPC。
@@ -192,12 +206,12 @@ impl Call for DeleteBucketRpc {
     const NAME: &'static str = "frugalos.config.bucket.delete";
 
     type Req = BucketId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = BucketIdDecoder;
+    type ReqEncoder = BucketIdEncoder;
 
     type Res = Result<Option<Bucket>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = DeleteBucketResponseDecoder;
+    type ResEncoder = DeleteBucketResponseEncoder;
 }
 
 /// Raftのリーダノード取得RPC。
@@ -209,10 +223,10 @@ impl Call for GetLeaderRpc {
     const NAME: &'static str = "frugalos.config.leader.get";
 
     type Req = ();
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = EmptyMessageDecoder;
+    type ReqEncoder = EmptyMessageEncoder;
 
     type Res = Result<SocketAddr>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = GetLeaderResponseDecoder;
+    type ResEncoder = GetLeaderResponseEncoder;
 }

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -18,14 +18,16 @@ use protobuf::repair::{RepairConfigDecoder, RepairConfigEncoder};
 use protobuf::schema::frugalos::{
     CountFragmentsRequestDecoder, CountFragmentsRequestEncoder, CountFragmentsResponseDecoder,
     CountFragmentsResponseEncoder, DeleteObjectSetFromDeviceRequestDecoder,
-    DeleteObjectSetFromDeviceRequestEncoder, EmptyResponseDecoder, EmptyResponseEncoder,
-    GetObjectResponseDecoder, GetObjectResponseEncoder, HeadObjectRequestDecoder,
-    HeadObjectRequestEncoder, ListObjectsRequestDecoder, ListObjectsRequestEncoder,
-    ObjectRequestDecoder, ObjectRequestEncoder, PrefixRequestDecoder, PrefixRequestEncoder,
-    PutObjectRequestDecoder, PutObjectRequestEncoder, PutObjectResponseDecoder,
-    PutObjectResponseEncoder, RangeRequestDecoder, RangeRequestEncoder, SegmentRequestDecoder,
-    SegmentRequestEncoder, StopResponseDecoder, StopResponseEncoder, TakeSnapshotResponseDecoder,
-    TakeSnapshotResponseEncoder, VersionRequestDecoder, VersionRequestEncoder,
+    DeleteObjectSetFromDeviceRequestEncoder, DeleteObjectSetFromDeviceResponseDecoder,
+    DeleteObjectSetFromDeviceResponseEncoder, GetObjectResponseDecoder, GetObjectResponseEncoder,
+    HeadObjectRequestDecoder, HeadObjectRequestEncoder, ListObjectsRequestDecoder,
+    ListObjectsRequestEncoder, ObjectRequestDecoder, ObjectRequestEncoder, PrefixRequestDecoder,
+    PrefixRequestEncoder, PutObjectRequestDecoder, PutObjectRequestEncoder,
+    PutObjectResponseDecoder, PutObjectResponseEncoder, RangeRequestDecoder, RangeRequestEncoder,
+    SegmentRequestDecoder, SegmentRequestEncoder, SetRepairConfigResponseDecoder,
+    SetRepairConfigResponseEncoder, StopResponseDecoder, StopResponseEncoder,
+    TakeSnapshotResponseDecoder, TakeSnapshotResponseEncoder, VersionRequestDecoder,
+    VersionRequestEncoder,
 };
 use protobuf::schema::object::{
     DeleteObjectsByPrefixSummaryResponseDecoder, DeleteObjectsByPrefixSummaryResponseEncoder,
@@ -208,8 +210,8 @@ impl Call for DeleteObjectSetFromDeviceRpc {
     type ReqEncoder = DeleteObjectSetFromDeviceRequestEncoder;
 
     type Res = Result<()>;
-    type ResDecoder = EmptyResponseDecoder;
-    type ResEncoder = EmptyResponseEncoder;
+    type ResDecoder = DeleteObjectSetFromDeviceResponseDecoder;
+    type ResEncoder = DeleteObjectSetFromDeviceResponseEncoder;
 }
 
 /// 接頭辞指定でのオブジェクト一覧取得RPC。
@@ -362,7 +364,7 @@ impl Call for StopRpc {
     const NAME: &'static str = "frugalos.ctrl.stop";
 
     type Req = ();
-    type ReqDecoder = EmptyMessageDecoder; // TODO use custom type
+    type ReqDecoder = EmptyMessageDecoder;
     type ReqEncoder = EmptyMessageEncoder;
 
     type Res = Result<()>;
@@ -378,7 +380,7 @@ impl Call for TakeSnapshotRpc {
     const NAME: &'static str = "frugalos.ctrl.take_snapshot";
 
     type Req = ();
-    type ReqDecoder = EmptyMessageDecoder; // TODO use custom type
+    type ReqDecoder = EmptyMessageDecoder;
     type ReqEncoder = EmptyMessageEncoder;
 
     type Res = Result<()>;
@@ -398,6 +400,6 @@ impl Call for SetRepairConfigRpc {
     type ReqDecoder = RepairConfigDecoder;
 
     type Res = Result<()>;
-    type ResEncoder = EmptyResponseEncoder;
-    type ResDecoder = EmptyResponseDecoder;
+    type ResEncoder = SetRepairConfigResponseEncoder;
+    type ResDecoder = SetRepairConfigResponseDecoder;
 }

--- a/src/schema/mds.rs
+++ b/src/schema/mds.rs
@@ -1,5 +1,4 @@
 //! MDS系RPCのスキーマ定義。
-use bytecodec::bincode_codec::{BincodeDecoder, BincodeEncoder};
 use fibers_rpc::{Call, Cast, ProcedureId};
 use std::ops::Range;
 use std::time::Duration;
@@ -10,6 +9,23 @@ use entity::object::{
     DeleteObjectsByPrefixSummary, Metadata, ObjectId, ObjectPrefix, ObjectSummary, ObjectVersion,
 };
 use expect::Expect;
+use protobuf::schema::mds::{
+    GetLatestVersionRequestDecoder, GetLatestVersionRequestEncoder, GetLeaderRequestDecoder,
+    GetLeaderRequestEncoder, GetLeaderResponseDecoder, GetLeaderResponseEncoder,
+    ListObjectsRequestDecoder, ListObjectsRequestEncoder, MaybeMetadataResponseDecoder,
+    MaybeMetadataResponseEncoder, ObjectCountRequestDecoder, ObjectCountRequestEncoder,
+    ObjectCountResponseDecoder, ObjectCountResponseEncoder, ObjectRequestDecoder,
+    ObjectRequestEncoder, PrefixRequestDecoder, PrefixRequestEncoder, PutObjectRequestDecoder,
+    PutObjectRequestEncoder, PutObjectResponseDecoder, PutObjectResponseEncoder,
+    RangeRequestDecoder, RangeRequestEncoder, RecommendToLeaderRequestDecoder,
+    RecommendToLeaderRequestEncoder, VersionRequestDecoder, VersionRequestEncoder,
+};
+use protobuf::schema::object::{
+    DeleteObjectsByPrefixSummaryResponseDecoder, DeleteObjectsByPrefixSummaryResponseEncoder,
+    MaybeObjectSummaryResponseDecoder, MaybeObjectSummaryResponseEncoder,
+    MaybeObjectVersionResponseDecoder, MaybeObjectVersionResponseEncoder,
+    ObjectSummarySequenceResponseDecoder, ObjectSummarySequenceResponseEncoder,
+};
 use Result;
 
 /// Raftのリーダ取得RPC。
@@ -19,13 +35,13 @@ impl Call for GetLeaderRpc {
     const ID: ProcedureId = ProcedureId(0x0007_0000);
     const NAME: &'static str = "frugalos.mds.leader.get";
 
-    type Req = LocalNodeId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type Req = GetLeaderRequest;
+    type ReqDecoder = GetLeaderRequestDecoder;
+    type ReqEncoder = GetLeaderRequestEncoder;
 
     type Res = Result<RemoteNodeId>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = GetLeaderResponseDecoder;
+    type ResEncoder = GetLeaderResponseEncoder;
 }
 
 /// リーダ推薦（再選挙）RPC。
@@ -35,9 +51,9 @@ impl Cast for RecommendToLeaderRpc {
     const ID: ProcedureId = ProcedureId(0x0007_0001);
     const NAME: &'static str = "frugalos.mds.leader.recommend";
 
-    type Notification = LocalNodeId;
-    type Decoder = BincodeDecoder<Self::Notification>;
-    type Encoder = BincodeEncoder<Self::Notification>;
+    type Notification = RecommendToLeaderRequest;
+    type Decoder = RecommendToLeaderRequestDecoder;
+    type Encoder = RecommendToLeaderRequestEncoder;
 }
 
 /// オブジェクト一覧取得RPC。
@@ -48,12 +64,12 @@ impl Call for ListObjectsRpc {
     const NAME: &'static str = "frugalos.mds.object.list";
 
     type Req = ListObjectsRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ListObjectsRequestDecoder;
+    type ReqEncoder = ListObjectsRequestEncoder;
 
     type Res = Result<Vec<ObjectSummary>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = ObjectSummarySequenceResponseDecoder;
+    type ResEncoder = ObjectSummarySequenceResponseEncoder;
 
     fn enable_async_response(_: &Self::Res) -> bool {
         true
@@ -68,12 +84,12 @@ impl Call for GetObjectRpc {
     const NAME: &'static str = "frugalos.mds.object.get";
 
     type Req = ObjectRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ObjectRequestDecoder;
+    type ReqEncoder = ObjectRequestEncoder;
 
     type Res = Result<Option<Metadata>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = MaybeMetadataResponseDecoder;
+    type ResEncoder = MaybeMetadataResponseEncoder;
 }
 
 /// オブジェクト存在確認RPC。
@@ -84,12 +100,12 @@ impl Call for HeadObjectRpc {
     const NAME: &'static str = "frugalos.mds.object.head";
 
     type Req = ObjectRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ObjectRequestDecoder;
+    type ReqEncoder = ObjectRequestEncoder;
 
     type Res = Result<Option<ObjectVersion>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = MaybeObjectVersionResponseDecoder;
+    type ResEncoder = MaybeObjectVersionResponseEncoder;
 }
 
 /// オブジェクト保存RPC。
@@ -100,12 +116,12 @@ impl Call for PutObjectRpc {
     const NAME: &'static str = "frugalos.mds.object.put";
 
     type Req = PutObjectRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = PutObjectRequestDecoder;
+    type ReqEncoder = PutObjectRequestEncoder;
 
     type Res = Result<(ObjectVersion, Option<ObjectVersion>)>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = PutObjectResponseDecoder;
+    type ResEncoder = PutObjectResponseEncoder;
 }
 
 /// オブジェクト削除RPC。
@@ -116,12 +132,12 @@ impl Call for DeleteObjectRpc {
     const NAME: &'static str = "frugalos.mds.object.delete";
 
     type Req = ObjectRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ObjectRequestDecoder;
+    type ReqEncoder = ObjectRequestEncoder;
 
     type Res = Result<Option<ObjectVersion>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = MaybeObjectVersionResponseDecoder;
+    type ResEncoder = MaybeObjectVersionResponseEncoder;
 }
 
 /// 最新バージョン取得RPC。
@@ -131,13 +147,13 @@ impl Call for GetLatestVersionRpc {
     const ID: ProcedureId = ProcedureId(0x0008_0005);
     const NAME: &'static str = "frugalos.mds.object.latest_version";
 
-    type Req = LocalNodeId;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type Req = GetLatestVersionRequest;
+    type ReqDecoder = GetLatestVersionRequestDecoder;
+    type ReqEncoder = GetLatestVersionRequestEncoder;
 
     type Res = Result<Option<ObjectSummary>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = MaybeObjectSummaryResponseDecoder;
+    type ResEncoder = MaybeObjectSummaryResponseEncoder;
 }
 
 /// バージョン指定による削除RPC。
@@ -148,12 +164,12 @@ impl Call for DeleteObjectByVersionRpc {
     const NAME: &'static str = "frugalos.mds.object.delete_by_version";
 
     type Req = VersionRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = VersionRequestDecoder;
+    type ReqEncoder = VersionRequestEncoder;
 
     type Res = Result<Option<ObjectVersion>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = MaybeObjectVersionResponseDecoder;
+    type ResEncoder = MaybeObjectVersionResponseEncoder;
 }
 
 /// バージョン範囲指定による削除RPC。
@@ -164,12 +180,12 @@ impl Call for DeleteObjectsByRangeRpc {
     const NAME: &'static str = "frugalos.mds.object.delete_by_range";
 
     type Req = RangeRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = RangeRequestDecoder;
+    type ReqEncoder = RangeRequestEncoder;
 
     type Res = Result<Vec<ObjectSummary>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = ObjectSummarySequenceResponseDecoder;
+    type ResEncoder = ObjectSummarySequenceResponseEncoder;
 }
 
 /// 格納済みオブジェクト数取得RPC。
@@ -180,12 +196,12 @@ impl Call for GetObjectCountRpc {
     const NAME: &'static str = "frugalos.mds.object.count";
 
     type Req = ObjectCountRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = ObjectCountRequestDecoder;
+    type ReqEncoder = ObjectCountRequestEncoder;
 
     type Res = Result<u64>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = ObjectCountResponseDecoder;
+    type ResEncoder = ObjectCountResponseEncoder;
 }
 
 /// 接頭辞削除RPC。
@@ -196,12 +212,12 @@ impl Call for DeleteObjectsByPrefixRpc {
     const NAME: &'static str = "frugalos.mds.object.delete_by_prefix";
 
     type Req = PrefixRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = PrefixRequestDecoder;
+    type ReqEncoder = PrefixRequestEncoder;
 
     type Res = Result<DeleteObjectsByPrefixSummary>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = DeleteObjectsByPrefixSummaryResponseDecoder;
+    type ResEncoder = DeleteObjectsByPrefixSummaryResponseEncoder;
 }
 
 /// 接頭辞指定でのオブジェクト一覧取得RPC。
@@ -212,16 +228,37 @@ impl Call for ListObjectsByPrefixRpc {
     const NAME: &'static str = "frugalos.mds.object.list_by_prefix";
 
     type Req = PrefixRequest;
-    type ReqDecoder = BincodeDecoder<Self::Req>;
-    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = PrefixRequestDecoder;
+    type ReqEncoder = PrefixRequestEncoder;
 
     type Res = Result<Vec<ObjectSummary>>;
-    type ResDecoder = BincodeDecoder<Self::Res>;
-    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = ObjectSummarySequenceResponseDecoder;
+    type ResEncoder = ObjectSummarySequenceResponseEncoder;
 
     fn enable_async_response(_: &Self::Res) -> bool {
         true
     }
+}
+
+/// リーダー取得要求。
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetLeaderRequest {
+    pub node_id: LocalNodeId,
+}
+
+/// リーダー再選挙要求。
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecommendToLeaderRequest {
+    pub node_id: LocalNodeId,
+}
+
+/// 最新バージョン取得要求。
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetLatestVersionRequest {
+    pub node_id: LocalNodeId,
 }
 
 /// オブジェクト単位の要求。

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,4 +1,36 @@
 //! RPCのスキーマ定義。
+//!
+//! # Compatibility Guideline
+//!
+//! ## 基本方針
+//!
+//! * Protocol Buffers のバージョンは 3 を利用する。
+//! * 後方互換性を損わないために Protocol Buffers のタグは絶対に再利用しない。
+//! * 互換性が崩れる時は `ProcedureId` を変更し、新しく RPC を定義し直す(既存の RPC を消さない)。
+//!     * 無停止でのバージョン切り替えなど一時的に互換性のないバージョンが共存できる状態にするため。
+//! * RPC のリクエスト/レスポンス型は専用の `struct` を極力利用する。
+//!     * 後方互換性を維持したままフィールドの追加/変更ができるようにするため。
+//!
+//! 互換性を崩す時に他の方針として、新旧で 2 つのフィールドを用意し双方にデータを入れて返すというやり方もあるが、
+//! ネットワーク帯域がシビアなユースケースを想定しているためこの方針は採用しない。
+//!
+//! ## Protocol Buffers の下位互換性のある変更
+//!
+//! * リクエスト形式に新しくフィールドを追加する
+//! * レスポンス形式に新しくフィールドを追加する
+//! * Protocol Buffers で認められている型の変更をする
+//! * 単一の値を取るフィールドを新しく追加した(新しいというのが重要) `oneof` に追加する
+//! * 既存の `oneof` に新しくフィールドを追加する
+//!     * ただし、新しく追加したフィールドを古いフォーマットしか知らないクライアントに返してはいけない。
+//!
+//! [https://developers.google.com/protocol-buffers/docs/proto3#updating](https://developers.google.com/protocol-buffers/docs/proto3#updating) をよく読み十分理解すること。
+//!
+//! ## Protocol Buffers の下位互換性のない変更
+//!
+//! * スカラ型(uint64 など)から `message` へ型を変更をする
+//! * `EmptyMessageDecoder`/`EmptyMessageEncoder` から別の `Encoder`/`Decoder` への変更をする
+//! * リクエスト形式自体(`String` から `struct Foo` など)の変更をする
+//! * レスポンス形式自体(`()` から `Result<Option<String>>` など)の変更をする
 pub mod config;
 pub mod frugalos;
 pub mod mds;


### PR DESCRIPTION
## 目的

Protocol Buffer に統一するためにフォーマットを変更すること。

## 変更点

* Protocol Buffers の恩恵を受けるために RPC リクエストで primitive な型を使わないようにする(フィールド追加がきないため)。
* RPC のフォーマットを bincode から Protocol Buffers に変更する。これにより**すべての** RPC で過去のバージョンと互換性がなくなる。

## 方針

* Protocol Buffers への decode/encode は `src/protobuf` に置く。
    * 可視性を考慮すると `struct` 定義と同じ module 内で Decoder/Encoder も定義した方がいいが(private なフィールドがあった場合にどうしようもないので)、`raftlog_protobuf` などの慣例に倣っている。
* Protocol Buffers のファイルはこの PR では追加しない。
    * frugalos の実装上は特に `*.proto` ファイルは必要ないため。
* Decoder/Encoder は型宣言できる方法で定義する。
    * `fibers_rpc::Call` が型を要求するため。
    * `protobuf_message_decoder!`, `protobuf_message_encoder!` マクロは使わない。
* 後々いわゆる `newtype` に変更される型エイリアス(例えば `ObjectId`)は decoder/encoder を型エイリアスで定義する。
* RPC レスポンスは `ResultDecoder`, `ResultEncoder`, `OptionDecoder`, `OptionEncoder`, `VecDecoder`, `VecEncoder` でまかなえる場合はこれらを使う。
    * 専用の型定義が必要になったら専用の Decoder/Encoder を追加する。
* `()` 型には `EmptyMessageDecoder/Encoder` を使う。
* `std::time::Duration` には `DurationMessageDecoder/Encoder` を使う。
* `protobuf_codec` にある `ErrorDecoder/ErrorEncoder` は使わない。
    * `Trackable<String>` が扱いづらく、独自の `ErrorDecoder/ErrorEncoder` を定義した方が良かったため。