### PR TITLE
Add TruncateBucketRpc

### DIFF
--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -275,13 +275,10 @@ impl Client {
         )
     }
 
-    /// Executes `DeleteBucketContentsRpc`
-    pub fn delete_bucket_contents(
-        &self,
-        bucket_seqno: u32,
-    ) -> impl Future<Item = (), Error = Error> {
+    /// Executes `TruncateBucketRpc`
+    pub fn truncate_bucket(&self, bucket_seqno: u32) -> impl Future<Item = (), Error = Error> {
         Response(
-            frugalos::DeleteBucketContentsRpc::client(&self.rpc_service)
+            frugalos::TruncateBucketRpc::client(&self.rpc_service)
                 .call(self.server, frugalos::BucketSeqnoRequest { bucket_seqno }),
         )
     }

--- a/src/client/frugalos.rs
+++ b/src/client/frugalos.rs
@@ -274,4 +274,15 @@ impl Client {
                 .call(self.server, repair_config),
         )
     }
+
+    /// Executes `DeleteBucketContentsRpc`
+    pub fn delete_bucket_contents(
+        &self,
+        bucket_seqno: u32,
+    ) -> impl Future<Item = (), Error = Error> {
+        Response(
+            frugalos::DeleteBucketContentsRpc::client(&self.rpc_service)
+                .call(self.server, frugalos::BucketSeqnoRequest { bucket_seqno }),
+        )
+    }
 }

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -382,3 +382,25 @@ impl Call for SetRepairConfigRpc {
     type ResEncoder = BincodeEncoder<Self::Res>;
     type ResDecoder = BincodeDecoder<Self::Res>;
 }
+
+/// バケツのデータ削除要求
+/// バケツ削除処理でデータ削除処理が失敗した場合に実施を想定
+pub struct DeleteBucketContentsRpc;
+impl Call for DeleteBucketContentsRpc {
+    const ID: ProcedureId = ProcedureId(0x000a_0003);
+    const NAME: &'static str = "frugalos.ctrl.delete_bucket_contents";
+
+    type Req = BucketSeqnoRequest;
+    type ReqEncoder = BincodeEncoder<Self::Req>;
+    type ReqDecoder = BincodeDecoder<Self::Req>;
+
+    type Res = Result<()>;
+    type ResEncoder = BincodeEncoder<Self::Res>;
+    type ResDecoder = BincodeDecoder<Self::Res>;
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BucketSeqnoRequest {
+    pub bucket_seqno: u32,
+}

--- a/src/schema/frugalos.rs
+++ b/src/schema/frugalos.rs
@@ -385,10 +385,10 @@ impl Call for SetRepairConfigRpc {
 
 /// バケツのデータ削除要求
 /// バケツ削除処理でデータ削除処理が失敗した場合に実施を想定
-pub struct DeleteBucketContentsRpc;
-impl Call for DeleteBucketContentsRpc {
+pub struct TruncateBucketRpc;
+impl Call for TruncateBucketRpc {
     const ID: ProcedureId = ProcedureId(0x000a_0003);
-    const NAME: &'static str = "frugalos.ctrl.delete_bucket_contents";
+    const NAME: &'static str = "frugalos.ctrl.truncate_bucket";
 
     type Req = BucketSeqnoRequest;
     type ReqEncoder = BincodeEncoder<Self::Req>;


### PR DESCRIPTION
https://github.com/frugalos/frugalos/pull/302 に関連した PR 

バケツ削除機能を追加する予定で、バケツ削除処理の途中で失敗した場合などでゴミデータが残ってしまった場合に後から削除するための処理 (=DeleteBucketContents) を呼び出すための RPC を追加します

処理の呼び出しには bucket のシーケンス番号のみを取ります